### PR TITLE
fix support for spawning 2+ instances

### DIFF
--- a/lib/stemcell.rb
+++ b/lib/stemcell.rb
@@ -151,7 +151,7 @@ module Stemcell
       @log.debug "about to launch instance(s) with options #{opts}"
       @log.info "launching instances"
       instances = @ec2.instances.create(opts)
-      instances = [instances] unless instances.class == AWS::Core::Data::List
+      instances = [instances] unless Array === instances
       instances.each do |instance|
         @log.info "launched instance #{instance.instance_id}"
       end


### PR DESCRIPTION
Avoid the following exception:

lib/stemcell.rb:157:in `block in do_launch': undefined method`instance_id' for #Array:0x007ff86ec32be8 (NoMethodError)
