### PR TITLE
Ensure we add instance storage for EBS instances.

### DIFF
--- a/lib/stemcell.rb
+++ b/lib/stemcell.rb
@@ -64,6 +64,11 @@ module Stemcell
         :instance_type => opts['instance_type'],
         :key_name => opts['key_name'],
         :count => opts['count'],
+        :block_device_mappings => {
+          "/dev/sdc" => "ephemeral1",
+          "/dev/sdd" => "ephemeral2",
+          "/dev/sde" => "ephemeral3",
+        },
       }
 
       # specify availability zone (optional)


### PR DESCRIPTION
We need to explicitely specify that we want to attach instance storage
volumes when launching instances with EBS root volumes.
