### PR TITLE
Ephemeral mapping support

### DIFF
--- a/bin/stemcell
+++ b/bin/stemcell
@@ -41,7 +41,7 @@ options = Trollop::options do
       )
 
   opt('security_groups',
-      'security groups to launch instance with',
+      'comma-separated list of security groups to launch instance with',
       :type => String,
       :default => ENV['SECURITY_GROUPS'] ? ENV['SECURITY_GROUPS'] : 'default'
       )
@@ -73,6 +73,12 @@ options = Trollop::options do
   opt('ebs_optimized',
       'launch an EBS-Optimized instance',
       :type => :flag
+      )
+
+  opt('ephemeral_devices',
+      'comma-separated list of block devices to map ephemeral devices to',
+      :type => String,
+      :default => ENV['EPHEMERAL_DEVICES']
       )
 
   opt('chef_data_bag_secret',
@@ -153,6 +159,10 @@ options['tags'] = tags
 options['security_groups'] = options['security_groups'].split(',')
 
 
+# convert ephemeral_devices from comma separated string to ruby array
+options['ephemeral_devices'] = options['ephemeral_devices'].split(',') if options['ephemeral_devices']
+
+
 # create stemcell object
 stemcell = Stemcell::Stemcell.new({
   'aws_access_key' => options['aws_access_key'],
@@ -178,4 +188,5 @@ stemcell.launch({
   'count'                => options['count'],
   'iam_role'             => options['iam_role'],
   'ebs_optimized'        => options['ebs_optimized'],
+  'ephemeral_devices'    => options['ephemeral_devices'],
 })

--- a/lib/stemcell.rb
+++ b/lib/stemcell.rb
@@ -75,6 +75,16 @@ module Stemcell
       # specify an EBS-optimized instance (optional)
       launch_options[:ebs_optimized] = true if opts['ebs_optimized']
 
+      # specify block device mappings (optional)
+      if opts['ephemeral_devices']
+        launch_options[:block_device_mappings] = opts['ephemeral_devices'].each_with_index.map do |device,i|
+          {
+            :device_name => device,
+            :virtual_name => "ephemeral#{i}"
+          }
+        end
+      end
+
       # generate user data script to bootstrap instance, include in launch optsions
       launch_options[:user_data] = render_template(opts)
 

--- a/stemcell.gemspec
+++ b/stemcell.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
-  gem.add_runtime_dependency 'trollop'
-  gem.add_runtime_dependency 'aws-sdk'
-  gem.add_runtime_dependency 'fog'
+  gem.add_runtime_dependency 'trollop', '~> 2.0'
+  gem.add_runtime_dependency 'aws-sdk', '~> 1.9'
+  gem.add_runtime_dependency 'fog', '~> 1.10'
 end
 


### PR DESCRIPTION
`hi1.4xlarge` boxes have 2 available 1TB SSD ephemeral volumes, but by default only one of them is mapped (as `/dev/xvdb`). To get the other one to show up, we need to specify block device mappings when we launch the instance. Unlike EBS volumes, ephemeral volumes must be specified at launch time; they cannot be attached later.

To launch a `hi1.x4large` box with both drives, use `--ephemeral-devices /dev/sdb,/dev/sdc`. They will show up as `/dev/xvdb` and `/dev/xvdc`.

/cc @martinrhoads @igor47 
