### PR TITLE
install chef via a dpkg

### DIFF
--- a/lib/stemcell/launcher.rb
+++ b/lib/stemcell/launcher.rb
@@ -30,6 +30,8 @@ module Stemcell
     ]
 
     LAUNCH_PARAMETERS = [
+      'chef_package_source',
+      'chef_version',
       'chef_role',
       'chef_environment',
       'chef_data_bag_secret',

--- a/lib/stemcell/metadata_source.rb
+++ b/lib/stemcell/metadata_source.rb
@@ -12,6 +12,8 @@ module Stemcell
       'count'            => 1,
       'instance_hostname' => '',
       'instance_domain_name' => '',
+      'chef_package_source' => 'http://www.opscode.com/chef/download?p=${platform}&pv=${platform_version}&m=${arch}&v=${chef_version}&prerelease=false',
+      'chef_version'      => '11.4.0',
     }
 
     # Search for instance metadata in the following role attributes, with

--- a/lib/stemcell/option_parser.rb
+++ b/lib/stemcell/option_parser.rb
@@ -125,6 +125,18 @@ module Stemcell
         :env  => 'CHEF_ROLE'
       },
       {
+        :name  => 'chef_version',
+        :desc  => "the chef version we will bootstrap on the box (defaults to 11.4.0)",
+        :type  => String,
+        :env   => 'CHEF_VERSION'
+      },
+      {
+        :name  => 'chef_package_source',
+        :desc  => "source of chef packages (defaults to https://opscode-omnibus-packages.s3.amazonaws.com)",
+        :type  => String,
+        :env   => 'CHEF_PACKAGE_SOURCE'
+      },
+      {
         :name  => 'chef_environment',
         :desc  => "chef environment in which this instance will run",
         :type  => String,

--- a/lib/stemcell/templates/bootstrap.sh.erb
+++ b/lib/stemcell/templates/bootstrap.sh.erb
@@ -57,8 +57,6 @@ echo $$ > ${PIDFILE}
 ## settings
 ##
 
-
-chef_version=11.4.0
 chef_dir=/etc/chef
 converge=/usr/local/bin/first_converge
 role=<%= opts['chef_role'] %>
@@ -112,14 +110,21 @@ set_hostname() {
 }
 
 install_chef() {
-  if ! which chef-solo > /dev/null ; then
-    echo installing chef via omnibus...
-    curl -L --silent https://www.opscode.com/chef/install.sh | sudo bash -s -- -v $chef_version  1>&2
-  else
-    echo chef is already installed
-  fi
-}
+  chef_version=<%= opts['chef_version'] %>
+  platform=`lsb_release -s -i | tr '[:upper:]' '[:lower:]'`
+  platform_version=`lsb_release -s -r`
+  arch=`uname -m`
+  package_url="<%= opts['chef_package_source'] %>"
 
+  package_local="/tmp/chef_${chef_version}.deb"
+  echo "Downloading chef from $package_url"
+  wget $package_url -O $package_local
+
+  echo "Installing chef $chef_version"
+  dpkg -i $package_local
+
+  rm $package_local
+}
 
 update_repo() {
   echo -e "$git_key" > $keyfile


### PR DESCRIPTION
this should be much safer than piping a random URL to bash. it gives us a clear
path to running stemcell with things other than ubuntu as well. it also allows us
to upgrade chef using chef on the resulting system.

@pcarrier @patrickviet @nelgau 
