### PR TITLE
[stemcell][simplify] short name if we're in production

### DIFF
--- a/lib/stemcell/launcher.rb
+++ b/lib/stemcell/launcher.rb
@@ -92,6 +92,8 @@ module Stemcell
         'created_by' => opts.fetch('user', ENV['USER']),
         'stemcell' => VERSION,
       }
+      # Short name if we're in production
+      tags['Name'] = opts['chef_role'] if opts['chef_environment'] == 'production'
       tags.merge!(opts['tags']) if opts['tags']
 
       # generate launch options


### PR DESCRIPTION
We don't even use environments - that -production suffix is just clutter in the aws console, in the billow output, etc
@igor47 @martinrhoads @pcarrier @daveaugustine 
