### PR TITLE
Remove git config from example stemcellrc

### DIFF
--- a/examples/stemcell.json
+++ b/examples/stemcell.json
@@ -3,7 +3,8 @@
     "region":"us-east-1",
     "security_groups": ["default"],
     "instance_type": "m1.small",
-    "backing_store": "instance_store"
+    "backing_store": "instance_store",
+    "git_origin": "git@github.com:YOUR_CHEF_REPO.git"
   },
 
   "backing_store": {

--- a/examples/stemcellrc
+++ b/examples/stemcellrc
@@ -20,10 +20,6 @@ CHEF_ENVIRONMENT=default
 #   modeled here: https://github.com/opscode/chef-repo
 export LOCAL_CHEF_ROOT=/path/to/your/local/chef/repository
 
-# The git origin is the publically-accessible version of the
-#   local chef root
-export GIT_ORIGIN=git@github.com:airbnb/chef.git
-
 # The git branch to use by default
 export GIT_BRANCH=production
 


### PR DESCRIPTION
The location is currently wrong (it's on Github Enterprise now) but it will
be automatically populated correctly, so we might as well just remove it.

cc @pcarrier @airbnb/sre
