### PR TITLE
Ability to specify security groups by id

### DIFF
--- a/lib/stemcell/launcher.rb
+++ b/lib/stemcell/launcher.rb
@@ -101,11 +101,19 @@ module Stemcell
       # generate launch options
       launch_options = {
         :image_id => opts['image_id'],
-        :security_groups => opts['security_groups'],
         :instance_type => opts['instance_type'],
         :key_name => opts['key_name'],
         :count => opts['count'],
       }
+      
+      # Specify security groups
+      # (takes group names or ids [identified via their 'sg-' prefix])
+      security_groups_option = opts['security_groups']
+      if security_groups_option.try(:first).try(:slice, 0, 3) == 'sg-'
+        launch_options[:security_group_ids] = security_groups_option
+      else
+        launch_options[:security_groups] = security_groups_option
+      end
 
       # specify availability zone (optional)
       if opts['availability_zone']


### PR DESCRIPTION
I just got stemcell to launch an instance. It's a very clever tool! :sailboat: 

A useful addition would be the ability to specify security groups via id as well as name. This patch enables that.

Related Ruby SDK documentation:
http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/EC2/InstanceCollection.html#create-instance_method
