### PR TITLE
Let Ohai know it's running on ec2

### DIFF
--- a/lib/stemcell/templates/bootstrap.sh.erb
+++ b/lib/stemcell/templates/bootstrap.sh.erb
@@ -101,6 +101,12 @@ install_chef() {
   fi
 }
 
+create_ohai_hint() {
+  ohai_hints_dir="${chef_dir}/ohai/hints"
+  mkdir -p $ohai_hints_dir
+  touch "${ohai_hints_dir}/ec2.json"
+}
+
 update_repo() {
   echo -e "$git_key" > $keyfile
   chmod 0400 $keyfile
@@ -230,6 +236,7 @@ install curl
 install git
 set_hostname
 install_chef
+create_ohai_hint
 update_repo
 configure_chef
 configure_converger


### PR DESCRIPTION
Ohai (tool built into chef, which exposes instance data such as processor, memory, network details) has an ec2 plugin, which is useful for determining VPC details, etc.

Since stemcell is targeting only ec2 it is convenient to install this ec2 hint automatically. Also, once chef has been launched it's trickier to make the adjustment, since ohai is run at the very start of chef recipes (thus, providing this from inside recipes is difficult).

For more details, see:
https://github.com/opscode/ohai/pull/73/files
