### PR TITLE
Use empty+nil instead of blank, fix issue with gp2 provisioning

### DIFF
--- a/lib/stemcell/option_parser.rb
+++ b/lib/stemcell/option_parser.rb
@@ -297,15 +297,15 @@ module Stemcell
 
               # a bit ugly but short and won't change
               # notice the to_i on volume_size parameter
-              mapping[:ebs][:snapshot_id] = devparam[0] unless devparam[0].blank?
+              mapping[:ebs][:snapshot_id] = devparam[0] unless (devparam[0].nil? || devparam[0].empty?)
               mapping[:ebs][:volume_size] = devparam[1].to_i
 
               # defaults to true - except if we have the exact string "false"
               mapping[:ebs][:delete_on_termination] = (devparam[2] != "false")
 
               # optional. notice the to_i on iops parameter
-              mapping[:ebs][:volume_type] = devparam[3] unless devparam[3].blank?
-              mapping[:ebs][:iops] = devparam[4].to_i if (devparam[4].to_i)
+              mapping[:ebs][:volume_type] = devparam[3] unless (devparam[3].nil? || devparam[3].empty?)
+              mapping[:ebs][:iops] = devparam[4].to_i unless (devparam[4].nil? || devparam[4].empty?)
 
             end
           end


### PR DESCRIPTION
- Replaces `blank?` with `empty? || nil?` (Rails ActiveSupport vs. ruby)
- Don't cast `nil` to `0` for `iops`, since the AWS SDK rejects `gp2` provisioning where an `iops` parameter is present.
