### PR TITLE
Provide a way for better for batch operation in stemcell

### DIFF
--- a/lib/stemcell/errors.rb
+++ b/lib/stemcell/errors.rb
@@ -27,6 +27,7 @@ module Stemcell
   class IncompleteOperation < Error
     attr_reader :operation, :all_instances, :finished_instances, :errors
     def initialize(operation, all_instances)
+      super()
       @operation = operation
       @all_instances = all_instances
 
@@ -36,6 +37,8 @@ module Stemcell
 
     def add_finished_instance(instance_id)
       @finished_instances << instance_id
+      # an instance may run into an error and get fixed later
+      @errors.delete(instance_id)
     end
 
     def add_error(instance_id, error)

--- a/lib/stemcell/errors.rb
+++ b/lib/stemcell/errors.rb
@@ -25,30 +25,17 @@ module Stemcell
   end
 
   class IncompleteOperation < Error
-    attr_reader :operation, :all_instances, :finished_instances, :errors
-    def initialize(operation, all_instances)
+    attr_reader :operation, :all_instance_ids, :errors
+    def initialize(operation, all_instance_ids, errors)
       super()
       @operation = operation
-      @all_instances = all_instances
-
-      @finished_instances = []
-      @errors = {}
-    end
-
-    def add_finished_instance(instance_id)
-      @finished_instances << instance_id
-      # an instance may run into an error and get fixed later
-      @errors.delete(instance_id)
-    end
-
-    def add_error(instance_id, error)
-      @errors[instance_id] = error
+      @all_instance_ids = all_instance_ids
+      @errors = errors
     end
 
     def message
       "Incomplete operation '#{@operation}': " +
-      "all_instances=#{@all_instances.join('|')}; " +
-      "finished_instances=#{@finished_instances.join('|')}; " +
+      "all_instance_ids=#{@all_instance_ids.join('|')}; " +
       "errors=" + (@errors.map { |k, v| "'#{k}' => '#{v}'"}.join('|'))
     end
   end

--- a/lib/stemcell/errors.rb
+++ b/lib/stemcell/errors.rb
@@ -23,4 +23,30 @@ module Stemcell
       @option = option
     end
   end
+
+  class IncompleteOperation < Error
+    attr_reader :operation, :all_instances, :finished_instances, :errors
+    def initialize(operation, all_instances)
+      @operation = operation
+      @all_instances = all_instances
+
+      @finished_instances = []
+      @errors = {}
+    end
+
+    def add_finished_instance(instance_id)
+      @finished_instances << instance_id
+    end
+
+    def add_error(instance_id, error)
+      @errors[instance_id] = error
+    end
+
+    def message
+      "Incomplete operation '#{@operation}': " +
+      "all_instances=#{@all_instances.join('|')}; " +
+      "finished_instances=#{@finished_instances.join('|')}; " +
+      "errors=" + (@errors.map { |k, v| "'#{k}' => '#{v}'"}.join('|'))
+    end
+  end
 end

--- a/lib/stemcell/launcher.rb
+++ b/lib/stemcell/launcher.rb
@@ -298,7 +298,7 @@ module Stemcell
           e
         end
       end
-      check_errors(:set_tags, instances.map { |i| i.id }, errors)
+      check_errors(:set_tags, instances.map(&:id), errors)
     end
 
     # attempt to accept keys as file paths

--- a/spec/lib/stemcell/launcher_spec.rb
+++ b/spec/lib/stemcell/launcher_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+class MockInstance
+  def initialize(id)
+    @id = id
+  end
+
+  def id
+    @id
+  end
+end
+
+describe Stemcell::Launcher do
+  describe '#run_batch_operation' do
+    instances = (1..4).map { |id| MockInstance.new(id) }
+
+    it "raises no exception when no internal error occur" do
+      expect do
+        Stemcell::Launcher::send(:run_batch_operation, instances) do
+          # do nothing
+        end
+      end.to_not raise_error
+    end
+
+    it "stop operation immediately when there is one error" do
+      error_message = "Incomplete operation 'one-error': all_instances=1|2|3|4; " +
+                      "finished_instances=1|2; errors='3' => 'error'"
+      expect do
+        # :stop_on_first_error will implicitly be set to be true
+        Stemcell::Launcher::send(
+            :run_batch_operation,
+            instances,
+            :operation => 'one-error') do |instance|
+          raise "error" if instance.id == 3
+        end
+      end.to raise_error(Stemcell::IncompleteOperation, error_message)
+    end
+
+    it "run full batch even when there are two error" do
+      error_message = "Incomplete operation 'two-errors': all_instances=1|2|3|4; " +
+                      "finished_instances=1|3; errors='2' => 'error-2'|'4' => 'error-4'"
+      expect do
+        Stemcell::Launcher::send(
+            :run_batch_operation,
+            instances,
+            :operation => 'two-errors',
+            :stop_on_first_error => false) do |instance|
+          raise "error-#{instance.id}" if instance.id % 2 == 0
+        end
+      end.to raise_error(Stemcell::IncompleteOperation, error_message)
+    end
+  end
+end

--- a/spec/lib/stemcell/launcher_spec.rb
+++ b/spec/lib/stemcell/launcher_spec.rb
@@ -14,98 +14,59 @@ class MockException < StandardError
 end
 
 describe Stemcell::Launcher do
+  let(:sleep) { mock("sleep")}
+  let(:launcher) {
+    opts = {}
+    Stemcell::Launcher::REQUIRED_OPTIONS.map { |k| opts[k] = "" }
+    launcher = Stemcell::Launcher.new(opts)
+    launcher
+  }
+  instances = (1..4).map { |id| MockInstance.new(id) }
+  instance_ids = instances.map { |i| i.id }
+
   OPERATION = 'op'
   describe '#run_batch_operation' do
-    instances = (1..4).map { |id| MockInstance.new(id) }
-    instance_ids = instances.map { |instance| instance.id }
-
-    opts = {}
-    Stemcell::Launcher::REQUIRED_OPTIONS.each { |k| opts[k] = "" }
-    launcher = Stemcell::Launcher.new(opts)
 
     it "raises no exception when no internal error occur" do
       expect do
-        launcher.send(:run_batch_operation, instances) do
-          # do nothing
-        end
-      end.to_not raise_error
+        errors = launcher.send(:run_batch_operation, instances) {}
+        errors.should be_empty
+      end
     end
 
-    it "stop operation immediately when there is one error" do
-      error_message = get_expected_error_message(instance_ids,
-                                                 [1, 2],
-                                                 { 3 => 'error' })
+    it "runs full batch even when there are two error" do
+      error_message = get_expected_error_message(
+        instance_ids,
+        [2, 4].map { |id| [id, "error-#{id}"] }
+      )
       expect do
-        # :stop_on_first_error will implicitly be set to be true
-        launcher.send(
-            :run_batch_operation,
-            instances,
-            :operation => OPERATION) do |instance|
-          raise "error" if instance.id == 3
-        end
-      end.to raise_error(Stemcell::IncompleteOperation, error_message)
-    end
-
-    it "run full batch even when there are two error" do
-      error_message = get_expected_error_message(instance_ids,
-                                                 [1, 3],
-                                                 { 2 => 'error-2', 4 => 'error-4' })
-      expect do
-        launcher.send(
-            :run_batch_operation,
-            instances,
-            :operation => OPERATION,
-            :stop_on_first_error => false) do |instance|
+        errors = launcher.send(:run_batch_operation,
+                               instances) do |instance, error|
           raise "error-#{instance.id}" if instance.id % 2 == 0
         end
+        launcher.send(:check_errors, OPERATION, instance_ids, errors)
       end.to raise_error(Stemcell::IncompleteOperation, error_message)
     end
 
-    retry_options = {
-      :max_retry => 3,
-      :interval_ms => 100,
-      :exceptions_to_retry => [MockException],
-    }
-    it "retry an operation from a intermittent error" do
+    it "resumes from an intermittent error" do
       count = 0
       expect do
-        launcher.send(
-            :run_batch_operation,
-            instances,
-            :operation => OPERATION,
-            :retry_options => retry_options) do |instance|
+        errors = launcher.send(:run_batch_operation,
+                               instances)  do |instance|
           if instance.id == 3
             count += 1
-            raise MockException, "error-#{instance.id}" if count < 3
+            raise AWS::EC2::Errors::InvalidInstanceID::NotFound, "error-#{instance.id}" if count < 3
           end
         end
-      end.to_not raise_error
-    end
-
-    it "fail because of too many retries" do
-      error_message = get_expected_error_message(instance_ids,
-                                                 [1, 2, 4],
-                                                 { 3 => 'error-3' })
-      expect do
-        launcher.send(
-            :run_batch_operation,
-            instances,
-            :operation => OPERATION,
-            :retry_options => retry_options) do |instance|
-          raise MockException, "error-#{instance.id}" if instance.id == 3
-        end
-      end.to raise_error(Stemcell::IncompleteOperation, error_message)
+        errors.should be_empty
+      end
     end
   end
 
   private
 
-  def get_expected_error_message(all_instances,
-                                 finished_instances,
-                                 errors)
-    exception = Stemcell::IncompleteOperation.new(OPERATION, all_instances )
-    finished_instances.each { |i| exception.add_finished_instance(i) }
-    errors.each { |instance, error| exception.add_error(instance, error) }
+  def get_expected_error_message(all_instances, errors)
+    exception = Stemcell::IncompleteOperation.new(OPERATION, all_instances, errors)
     exception.message
   end
 end

--- a/spec/lib/stemcell/launcher_spec.rb
+++ b/spec/lib/stemcell/launcher_spec.rb
@@ -10,44 +10,102 @@ class MockInstance
   end
 end
 
+class MockException < StandardError
+end
+
 describe Stemcell::Launcher do
+  OPERATION = 'op'
   describe '#run_batch_operation' do
     instances = (1..4).map { |id| MockInstance.new(id) }
+    instance_ids = instances.map { |instance| instance.id }
+
+    opts = {}
+    Stemcell::Launcher::REQUIRED_OPTIONS.each { |k| opts[k] = "" }
+    launcher = Stemcell::Launcher.new(opts)
 
     it "raises no exception when no internal error occur" do
       expect do
-        Stemcell::Launcher::send(:run_batch_operation, instances) do
+        launcher.send(:run_batch_operation, instances) do
           # do nothing
         end
       end.to_not raise_error
     end
 
     it "stop operation immediately when there is one error" do
-      error_message = "Incomplete operation 'one-error': all_instances=1|2|3|4; " +
-                      "finished_instances=1|2; errors='3' => 'error'"
+      error_message = get_expected_error_message(instance_ids,
+                                                 [1, 2],
+                                                 { 3 => 'error' })
       expect do
         # :stop_on_first_error will implicitly be set to be true
-        Stemcell::Launcher::send(
+        launcher.send(
             :run_batch_operation,
             instances,
-            :operation => 'one-error') do |instance|
+            :operation => OPERATION) do |instance|
           raise "error" if instance.id == 3
         end
       end.to raise_error(Stemcell::IncompleteOperation, error_message)
     end
 
     it "run full batch even when there are two error" do
-      error_message = "Incomplete operation 'two-errors': all_instances=1|2|3|4; " +
-                      "finished_instances=1|3; errors='2' => 'error-2'|'4' => 'error-4'"
+      error_message = get_expected_error_message(instance_ids,
+                                                 [1, 3],
+                                                 { 2 => 'error-2', 4 => 'error-4' })
       expect do
-        Stemcell::Launcher::send(
+        launcher.send(
             :run_batch_operation,
             instances,
-            :operation => 'two-errors',
+            :operation => OPERATION,
             :stop_on_first_error => false) do |instance|
           raise "error-#{instance.id}" if instance.id % 2 == 0
         end
       end.to raise_error(Stemcell::IncompleteOperation, error_message)
     end
+
+    retry_options = {
+      :max_retry => 3,
+      :interval_ms => 100,
+      :exceptions_to_retry => [MockException],
+    }
+    it "retry an operation from a intermittent error" do
+      count = 0
+      expect do
+        launcher.send(
+            :run_batch_operation,
+            instances,
+            :operation => OPERATION,
+            :retry_options => retry_options) do |instance|
+          if instance.id == 3
+            count += 1
+            raise MockException, "error-#{instance.id}" if count < 3
+          end
+        end
+      end.to_not raise_error
+    end
+
+    it "fail because of too many retries" do
+      error_message = get_expected_error_message(instance_ids,
+                                                 [1, 2, 4],
+                                                 { 3 => 'error-3' })
+      expect do
+        launcher.send(
+            :run_batch_operation,
+            instances,
+            :operation => OPERATION,
+            :retry_options => retry_options) do |instance|
+          raise MockException, "error-#{instance.id}" if instance.id == 3
+        end
+      end.to raise_error(Stemcell::IncompleteOperation, error_message)
+    end
+  end
+
+  private
+
+  def get_expected_error_message(all_instances,
+                                 finished_instances,
+                                 errors)
+    exception = Stemcell::IncompleteOperation.new(OPERATION, all_instances )
+    finished_instances.each { |i| exception.add_finished_instance(i) }
+    errors.each { |instance, error| exception.add_error(instance, error) }
+    exception.message
   end
 end

--- a/spec/lib/stemcell/launcher_spec.rb
+++ b/spec/lib/stemcell/launcher_spec.rb
@@ -14,59 +14,45 @@ class MockException < StandardError
 end
 
 describe Stemcell::Launcher do
-  let(:sleep) { mock("sleep")}
   let(:launcher) {
     opts = {}
     Stemcell::Launcher::REQUIRED_OPTIONS.map { |k| opts[k] = "" }
     launcher = Stemcell::Launcher.new(opts)
     launcher
   }
-  instances = (1..4).map { |id| MockInstance.new(id) }
-  instance_ids = instances.map { |i| i.id }
+  let(:operation) { 'op' }
+  let(:instances) { (1..4).map { |id| MockInstance.new(id) } }
+  let(:instance_ids) { instances.map(&:id) }
 
-  OPERATION = 'op'
   describe '#run_batch_operation' do
 
     it "raises no exception when no internal error occur" do
-      expect do
-        errors = launcher.send(:run_batch_operation, instances) {}
-        errors.should be_empty
-      end
+      errors = launcher.send(:run_batch_operation, instances) {}
+      errors.all?(&:nil?).should be_true
     end
 
     it "runs full batch even when there are two error" do
-      error_message = get_expected_error_message(
-        instance_ids,
-        [2, 4].map { |id| [id, "error-#{id}"] }
-      )
-      expect do
-        errors = launcher.send(:run_batch_operation,
-                               instances) do |instance, error|
-          raise "error-#{instance.id}" if instance.id % 2 == 0
-        end
-        launcher.send(:check_errors, OPERATION, instance_ids, errors)
-      end.to raise_error(Stemcell::IncompleteOperation, error_message)
-    end
-
-    it "resumes from an intermittent error" do
-      count = 0
-      expect do
-        errors = launcher.send(:run_batch_operation,
-                               instances)  do |instance|
-          if instance.id == 3
-            count += 1
-            raise AWS::EC2::Errors::InvalidInstanceID::NotFound, "error-#{instance.id}" if count < 3
-          end
-        end
-        errors.should be_empty
+      errors = launcher.send(:run_batch_operation,
+                             instances) do |instance, error|
+        raise "error-#{instance.id}" if instance.id % 2 == 0
       end
+      errors.count(&:nil?).should be_eql(2)
+      errors.reject(&:nil?).map { |e| e.message }.should \
+        be_eql([2, 4].map { |id| "error-#{id}" })
     end
-  end
 
-  private
-
-  def get_expected_error_message(all_instances, errors)
-    exception = Stemcell::IncompleteOperation.new(OPERATION, all_instances, errors)
-    exception.message
+    it "retries after an intermittent error" do
+      count = 0
+      errors = launcher.send(:run_batch_operation,
+                             instances)  do |instance|
+        if instance.id == 3
+          count += 1
+          count < 3 ?
+            AWS::EC2::Errors::InvalidInstanceID::NotFound.new("error-#{instance.id}"):
+            nil
+        end
+      end
+      errors.all?(&:nil?).should be_true
+    end
   end
 end


### PR DESCRIPTION
There are two relatively atomic commits in this PR:

1. Provide a more generic way to run batch operation against AWS instances (you can treat it as an enhanced way to do `instances.each`), which is flexible and reports much more detailed batch-related error message.
2. Based on the first commit, this commit add a retry mechanism to address the previous notorious "eventual consistency": set_tags may failed because AWS thinks these instances are not yet launched.

cc: @igor47 @jtai 