### PR TITLE
Make stemcell more robust

### DIFF
--- a/lib/stemcell/launcher.rb
+++ b/lib/stemcell/launcher.rb
@@ -244,14 +244,14 @@ module Stemcell
                 "instance(s) (#{instances.inspect}):"
 
       while true
-        sleep 5
-        if Time.now - @start_time > @timeout
+        break if instances.select{|i| i.status != :running }.empty?
+
+        elapsed = Time.now - @start_time
+        if elapsed >= @timeout
           kill(instances)
           raise TimeoutError, "exceded timeout of #{@timeout}"
-        end
-
-        if instances.select{|i| i.status != :running }.empty?
-          break
+        else
+          sleep min(5, @timeout - elapsed)
         end
       end
 


### PR DESCRIPTION
This PR also contains two commits:

1. Improve the logic in `Launcher::wait` which doesn't seem to be very legit.
2. make launch() more transaction-like: kill all launched instances if error occurs during the after-launch operations.

cc @jtai @igor47 