### PR TITLE
Quicly add file lock

### DIFF
--- a/lib/stemcell/templates/bootstrap.sh.erb
+++ b/lib/stemcell/templates/bootstrap.sh.erb
@@ -8,6 +8,11 @@
 # Martin Rhoads
 
 
+(
+echo 'Acquiring converge lock...'
+/usr/bin/flock -e 200
+echo 'Lock acquired!'
+
 set -o pipefail
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
@@ -253,3 +258,4 @@ configure_chef_daemon
 
 
 echo "<%= last_bootstrap_line %>"
+) 200> /var/run/converge.lock


### PR DESCRIPTION
This is a quick fix to avoid other script from updating chef repo
while bootstrap script is still running.

I felt that I'd have a more configurable & elegant way to specify
the file lock, but before I can find a better solution, let me just
come up with this working solution.

cc @jtai @igor47 