### PR TITLE
allow passing in instance-initiated shutdown behavior

### DIFF
--- a/lib/stemcell/launcher.rb
+++ b/lib/stemcell/launcher.rb
@@ -161,6 +161,12 @@ module Stemcell
       # specify an EBS-optimized instance (optional)
       launch_options[:ebs_optimized] = true if opts['ebs_optimized']
 
+      # specify placement group (optional)
+      if opts['instance_initiated_shutdown_behavior']
+        launch_options[:instance_initiated_shutdown_behavior] =
+          opts['instance_initiated_shutdown_behavior']
+      end
+
       # specify raw block device mappings (optional)
       if opts['block_device_mappings']
         launch_options[:block_device_mappings] = opts['block_device_mappings']

--- a/lib/stemcell/option_parser.rb
+++ b/lib/stemcell/option_parser.rb
@@ -138,6 +138,12 @@ module Stemcell
         :env   => 'EBS_OPTIMIZED'
       },
       {
+        :name  => 'instance_initiated_shutdown_behavior',
+        :desc  => "What happens when the instance shuts down? ('stop' or 'terminate')",
+        :type  => String,
+        :default => 'stop',
+      },
+      {
         :name  => 'block_device_mappings',
         :desc  => 'block device mappings',
         :type  => String,


### PR DESCRIPTION
allows us to determine what happens to the instance if the shutdown command is
executed inside it

to: @liukai @nelgau @jtai 