### PR TITLE
Don't require AWS keys to launch instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
+# 0.9.1
+- Don't require aws keys for Stemcell::Launcher to allow for launching via iam role
 
-# next release
+# 0.9.0
 - ...
 
 # 0.8.1

--- a/lib/stemcell/launcher.rb
+++ b/lib/stemcell/launcher.rb
@@ -10,8 +10,6 @@ module Stemcell
   class Launcher
 
     REQUIRED_OPTIONS = [
-      'aws_access_key',
-      'aws_secret_key',
       'region'
     ]
 
@@ -78,9 +76,12 @@ module Stemcell
       @timeout = 300
       @start_time = Time.new
 
-      AWS.config({
+      aws_configs = {:region => @region}
+      aws_configs.merge!({
         :access_key_id     => @aws_access_key,
-        :secret_access_key => @aws_secret_key})
+        :secret_access_key => @aws_secret_key
+      }) if @aws_access_key && @aws_secret_key
+      AWS.config(aws_configs)
 
       if opts['vpc_id']
         puts 'using vpc tho'

--- a/lib/stemcell/version.rb
+++ b/lib/stemcell/version.rb
@@ -1,3 +1,3 @@
 module Stemcell
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 end


### PR DESCRIPTION
This will let machines launch using IAM roles

@igor47 @jtai 