### PR TITLE
`min` must be called on enumerable

### DIFF
--- a/lib/stemcell/launcher.rb
+++ b/lib/stemcell/launcher.rb
@@ -267,7 +267,7 @@ module Stemcell
         if elapsed >= @timeout
           raise TimeoutError, "exceded timeout of #{@timeout}"
         else
-          sleep min(5, @timeout - elapsed)
+          sleep [5, @timeout - elapsed].min
         end
       end
 


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/airbnb/stemcell/commit/118dac1d7937da962dbd48a5dec50499c8dd928c.