### PR TITLE
Additional options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
+sudo: false
 language: ruby
+cache: bundler
 rvm:
   - 1.9.3
   - 2.1.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ cache: bundler
 rvm:
   - 1.9.3
   - 2.1.2
-  - 2.2.0
-  - ruby-head
+  - 2.2.4
+  - 2.3.1

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'rspec', '~> 2.14.1'
-  gem 'rspec-instafail', '~> 0.2.4'
+  gem 'rspec', '~> 3.4'
   gem 'simplecov', :require => false
   gem 'rake', '~> 10.3.2'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -4,5 +4,5 @@ task :default => :spec
 
 RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = 'spec/**/*_spec.rb'
-  spec.rspec_opts = ['-cfs --backtrace']
+  spec.rspec_opts = ['-c --backtrace']
 end

--- a/lib/stemcell/launcher.rb
+++ b/lib/stemcell/launcher.rb
@@ -53,6 +53,7 @@ module Stemcell
       'tags',
       'iam_role',
       'ebs_optimized',
+      'termination_protection',
       'block_device_mappings',
       'ephemeral_devices',
       'placement_group'
@@ -161,6 +162,9 @@ module Stemcell
 
       # specify an EBS-optimized instance (optional)
       launch_options[:ebs_optimized] = true if opts['ebs_optimized']
+
+      # specify termination protection (optional)
+      launch_options[:disable_api_termination] = true if opts['termination_protection']
 
       # specify placement group (optional)
       if opts['instance_initiated_shutdown_behavior']

--- a/lib/stemcell/launcher.rb
+++ b/lib/stemcell/launcher.rb
@@ -276,7 +276,7 @@ module Stemcell
         if elapsed >= @timeout
           raise TimeoutError, "exceded timeout of #{@timeout}"
         else
-          sleep min(5, @timeout - elapsed)
+          sleep [5, @timeout - elapsed].min
         end
       end
 

--- a/lib/stemcell/launcher.rb
+++ b/lib/stemcell/launcher.rb
@@ -225,16 +225,11 @@ module Stemcell
       return instances
     end
 
-    def find_instance(id)
-      return @ec2.instances[id]
-    end
+    def kill(instances, opts={})
+      return if !instances || instances.empty?
 
-    def kill(instance_ids, opts={})
-      return if instance_ids.nil?
-
-      errors = run_batch_operation(instance_ids) do |id|
+      errors = run_batch_operation(instances) do |instance|
         begin
-          instance = find_instance(id)
           @log.warn "Terminating instance #{instance.instance_id}"
           instance.terminate
           nil # nil == success
@@ -242,7 +237,7 @@ module Stemcell
           opts[:ignore_not_found] ? nil : e
         end
       end
-      check_errors(:kill, instance_ids, errors)
+      check_errors(:kill, instances.map(&:id), errors)
     end
 
     # this is made public for ec2admin usage

--- a/lib/stemcell/option_parser.rb
+++ b/lib/stemcell/option_parser.rb
@@ -138,6 +138,12 @@ module Stemcell
         :env   => 'EBS_OPTIMIZED'
       },
       {
+        :name  => 'termination_protection',
+        :desc  => "Prevent created instances from being terminated via the API",
+        :type  => String,
+        :env   => 'TERMINATION_PROTECTION'
+      },
+      {
         :name  => 'instance_initiated_shutdown_behavior',
         :desc  => "What happens when the instance shuts down? ('stop' or 'terminate')",
         :type  => String,

--- a/lib/stemcell/option_parser.rb
+++ b/lib/stemcell/option_parser.rb
@@ -160,6 +160,7 @@ module Stemcell
         :desc  => "What happens when the instance shuts down? ('stop' or 'terminate')",
         :type  => String,
         :default => 'stop',
+        :env   => 'INSTANCE_INITIATED_SHUTDOWN_BEHAVIOR',
       },
       {
         :name  => 'block_device_mappings',

--- a/lib/stemcell/option_parser.rb
+++ b/lib/stemcell/option_parser.rb
@@ -84,6 +84,18 @@ module Stemcell
         :env   => 'VPC_ID'
       },
       {
+        :name  => 'classic_link_vpc_id',
+        :desc  => 'VPC ID to which this instance will be classic-linked',
+        :type  => String,
+        :env   => 'CLASSIC_LINK_VPC_ID',
+      },
+      {
+        :name  => 'classic_link_security_group_ids',
+        :desc  => 'comma-separated list of security group IDs to link into ClassicLink; not used unless classic_link_vpc_id is set',
+        :type  => String,
+        :env   => 'CLASSIC_LINK_SECURITY_GROUP_IDS',
+      },
+      {
         :name  => 'subnet',
         :desc  => "VPC subnet for which to launch this instance",
         :type  => String,
@@ -369,6 +381,12 @@ module Stemcell
       options['security_group_ids'] &&= options['security_group_ids'].split(',')
       # convert ephemeral_devices from comma separated string to ruby array
       options['ephemeral_devices'] &&= options['ephemeral_devices'].split(',')
+
+      # format the classic link options
+      options['classic_link'] = {
+        'vpc_id' => options['classic_link_vpc_id'],
+        'security_group_ids' => options['classic_link_security_group_ids'],
+      }
 
       options
     end

--- a/lib/stemcell/option_parser.rb
+++ b/lib/stemcell/option_parser.rb
@@ -384,10 +384,10 @@ module Stemcell
       options['ephemeral_devices'] &&= options['ephemeral_devices'].split(',')
 
       # format the classic link options
-      options['classic_link'] = {
-        'vpc_id' => options['classic_link_vpc_id'],
-        'security_group_ids' => options['classic_link_security_group_ids'],
-      }
+      options['classic_link']['vpc_id'] = \
+        options['classic_link_vpc_id'] if options['classic_link_vpc_id']
+      options['classic_link']['security_group_ids'] = \
+        options['classic_link_security_group_ids'] if options['classic_link_security_group_ids']
 
       options
     end

--- a/lib/stemcell/option_parser.rb
+++ b/lib/stemcell/option_parser.rb
@@ -384,10 +384,12 @@ module Stemcell
       options['ephemeral_devices'] &&= options['ephemeral_devices'].split(',')
 
       # format the classic link options
-      options['classic_link']['vpc_id'] = \
-        options['classic_link_vpc_id'] if options['classic_link_vpc_id']
-      options['classic_link']['security_group_ids'] = \
-        options['classic_link_security_group_ids'] if options['classic_link_security_group_ids']
+      if options['classic_link_vpc_id']
+        options['classic_link']['vpc_id'] = options['classic_link_vpc_id']
+      end
+      if options['classic_link_security_group_ids']
+        options['classic_link']['security_group_ids'] = options['classic_link_security_group_ids']
+      end
 
       options
     end

--- a/spec/lib/stemcell/launcher_spec.rb
+++ b/spec/lib/stemcell/launcher_spec.rb
@@ -28,7 +28,7 @@ describe Stemcell::Launcher do
 
     it "raises no exception when no internal error occur" do
       errors = launcher.send(:run_batch_operation, instances) {}
-      errors.all?(&:nil?).should be_true
+      expect(errors.all?(&:nil?)).to be true
     end
 
     it "runs full batch even when there are two error" do
@@ -36,8 +36,8 @@ describe Stemcell::Launcher do
                              instances) do |instance, error|
         raise "error-#{instance.id}" if instance.id % 2 == 0
       end
-      errors.count(&:nil?).should be_eql(2)
-      errors.reject(&:nil?).map { |e| e.message }.should \
+      expect(errors.count(&:nil?)).to be_eql(2)
+      expect(errors.reject(&:nil?).map { |e| e.message }).to \
         be_eql([2, 4].map { |id| "error-#{id}" })
     end
 
@@ -52,7 +52,7 @@ describe Stemcell::Launcher do
             nil
         end
       end
-      errors.all?(&:nil?).should be_true
+      expect(errors.all?(&:nil?)).to be true
     end
   end
 end

--- a/spec/lib/stemcell/metadata_source_spec.rb
+++ b/spec/lib/stemcell/metadata_source_spec.rb
@@ -68,10 +68,10 @@ describe Stemcell::MetadataSource do
     let(:expand_options)     { Hash.new }
 
     before do
-      config.stub(:default_options) { default_options }
-      config.stub(:availability_zones) { availability_zones }
-      config.stub(:options_for_backing_store) { backing_options }
-      chef_repo.stub(:metadata_for_role) { role_metadata }
+      allow(config).to receive(:default_options) { default_options }
+      allow(config).to receive(:availability_zones) { availability_zones }
+      allow(config).to receive(:options_for_backing_store) { backing_options }
+      allow(chef_repo).to receive(:metadata_for_role) { role_metadata }
     end
 
     let(:role)        { 'role' }
@@ -159,13 +159,13 @@ describe Stemcell::MetadataSource do
         it "calls the config object to retrieve the backing store options" do
           backing_options.merge!('image_id' => 'ami-nyancat')
           override_options.merge!('backing_store' => 'ebs')
-          config.should_receive(:options_for_backing_store).with('ebs') { backing_options }
+          expect(config).to receive(:options_for_backing_store).with('ebs') { backing_options }
           expect(expansion['image_id']).to eql 'ami-nyancat'
         end
 
         it "calls the repository object to determine the role metadata" do
           role_metadata.merge!('image_id' => 'ami-nyancat')
-          chef_repo.should_receive(:metadata_for_role).with(role, environment) { role_metadata }
+          expect(chef_repo).to receive(:metadata_for_role).with(role, environment) { role_metadata }
           expect(expansion['image_id']).to eql 'ami-nyancat'
         end
 

--- a/spec/lib/stemcell/option_parser_spec.rb
+++ b/spec/lib/stemcell/option_parser_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Stemcell::OptionParser do
+  describe '#parse!' do
+    it 'returns a hash containing all of the options' do
+      result = subject.parse!([])
+      expect(result).to be_an_instance_of(Hash)
+
+      possible_keys = described_class::OPTION_DEFINITIONS.map { |d| d[:name] }
+      expect(result).to include(*possible_keys)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-require 'rspec/instafail'
 require 'simplecov'
 
 require 'stemcell'
@@ -9,5 +8,5 @@ SimpleCov.start do
 end
 
 RSpec.configure do |config|
-  config.color_enabled = true
+  config.color = true
 end

--- a/stemcell.gemspec
+++ b/stemcell.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.name          = "stemcell"
   s.version       = Stemcell::VERSION
   s.authors       = ["Martin Rhoads", "Igor Serebryany", "Nelson Gauthier", "Patrick Viet"]
-  s.email         = ["martin.rhoads@airbnb.com", "igor.serebryany@airbnb.com"]
+  s.email         = ["igor.serebryany@airbnb.com"]
   s.description   = %q{A tool for launching and bootstrapping EC2 instances}
   s.summary       = %q{no summary}
   s.homepage      = "https://github.com/airbnb/stemcell"
@@ -24,6 +24,11 @@ Gem::Specification.new do |s|
   else
     s.add_runtime_dependency 'chef',     ['>= 11.4.0', '< 12.0.0']
   end
+
+  # this is a transitive dependency, but the latest vesion has a late ruby
+  # version dependency. lets explicitly include it here. if this becomes
+  # no-longer a dependency of chef via chef-zero, then remove it
+  s.add_runtime_dependency 'rack', '< 2.0.0'
 
   s.add_runtime_dependency 'trollop',    '~> 2.1'
   s.add_runtime_dependency 'aws-creds',  '~> 0.2.3'


### PR DESCRIPTION
This allows two new options we're starting to use on our instances. One is termination protection (used on a few critical instances) and the other is ClassicLink (to enable VPC migration). We've been making these sorts of changes to instances manually after launching with stemcell, but after this PR we'll be able to just put these into the instance metadata as usual:

```ruby
    'instance_metadata' => {
      'termination_protection' => true,
      'classic_link' => {
        'vpc_id' => '#id',
        'security_group_ids' => ['#gid1', '#gid2'],
      },
    }
```

to: @jtai @nwadams 