### PR TITLE
[launcher] Don't make key_name a required launch parameter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.10.2
+- Don't make 'key_name' a required launch parameter.
+
 # 0.9.1
 - Don't require aws keys for Stemcell::Launcher to allow for launching via iam role
 

--- a/lib/stemcell/launcher.rb
+++ b/lib/stemcell/launcher.rb
@@ -19,7 +19,6 @@ module Stemcell
       'git_branch',
       'git_key',
       'git_origin',
-      'key_name',
       'instance_type',
       'image_id',
       'availability_zone',
@@ -103,9 +102,12 @@ module Stemcell
       launch_options = {
         :image_id => opts['image_id'],
         :instance_type => opts['instance_type'],
-        :key_name => opts['key_name'],
         :count => opts['count'],
       }
+
+      if opts['key_name']
+        launch_options[:key_name] = opts['key_name']
+      end
 
       if opts['security_groups'] && !opts['security_groups'].empty?
         launch_options[:security_groups] = opts['security_groups']

--- a/lib/stemcell/version.rb
+++ b/lib/stemcell/version.rb
@@ -1,3 +1,3 @@
 module Stemcell
-  VERSION = "0.10.1"
+  VERSION = "0.10.2"
 end


### PR DESCRIPTION
to: @igor47 @jtai 
cc: @josephsofaer @ziliangpeng 

This allows us to launch an instance when a convenient key pair may not be available (eg. a CI job). AWS does not require a key pair to be specified when launching instances, so instances launched without a key pair will not be accessible via the `ubuntu` user unless alternate means are provided.