### PR TITLE
adds ability to override certain values based on context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # 0.11.0
 - allow user to specify `contexts` to override certain attributes
 
+# 0.10.1
+- check for nil classic link
+
+# 0.10.0
+- allow launching termination-protected instances
+- enable classic link
+
 # 0.9.1
 - Don't require aws keys for Stemcell::Launcher to allow for launching via iam role
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.11.0
+- allow user to specify `contexts` to override certain attributes
+
 # 0.9.1
 - Don't require aws keys for Stemcell::Launcher to allow for launching via iam role
 

--- a/lib/stemcell/metadata_launcher.rb
+++ b/lib/stemcell/metadata_launcher.rb
@@ -35,12 +35,14 @@ module Stemcell
     end
 
     def determine_options(role, environment, override_options)
+      override_contexts = override_options.delete('contexts').split(',') rescue []
       # Initially assume that empty roles are not allowed
       allow_empty = false
       begin
         return source.expand_role(
           role,
           environment,
+          override_contexts,
           override_options,
           :allow_empty_roles => allow_empty)
       rescue EmptyRoleError

--- a/lib/stemcell/metadata_launcher.rb
+++ b/lib/stemcell/metadata_launcher.rb
@@ -35,14 +35,14 @@ module Stemcell
     end
 
     def determine_options(role, environment, override_options)
-      override_contexts = override_options.delete('contexts').split(',') rescue []
+      contexts = override_options.delete('contexts').split(',') rescue []
       # Initially assume that empty roles are not allowed
       allow_empty = false
       begin
         return source.expand_role(
           role,
           environment,
-          override_contexts,
+          contexts,
           override_options,
           :allow_empty_roles => allow_empty)
       rescue EmptyRoleError

--- a/lib/stemcell/metadata_source.rb
+++ b/lib/stemcell/metadata_source.rb
@@ -43,7 +43,7 @@ module Stemcell
       DEFAULT_OPTIONS.merge(config.default_options)
     end
 
-    def expand_role(role, environment, override_contexts=[], override_options={}, options={})
+    def expand_role(role, environment, contexts=[], override_options={}, options={})
       raise ArgumentError, "Missing chef role" unless role
       raise ArgumentError, "Missing chef environment" unless environment
       allow_empty_roles = options.fetch(:allow_empty_roles, false)
@@ -58,10 +58,11 @@ module Stemcell
       # Step 1.5: Override context specific values
       if !role_empty
         context_overrides = role_options['context_overrides'] || {}
-        override_contexts.each { |context|
+        contexts.each do |context|
           overriding_hash = context_overrides[context]
           role_options.merge!(overriding_hash) if overriding_hash
-        }
+        end
+        role_options.delete('context_overrides')
       end
 
       # Step 2: Determine the backing store from available options.

--- a/lib/stemcell/metadata_source.rb
+++ b/lib/stemcell/metadata_source.rb
@@ -43,7 +43,7 @@ module Stemcell
       DEFAULT_OPTIONS.merge(config.default_options)
     end
 
-    def expand_role(role, environment, override_options={}, options={})
+    def expand_role(role, environment, override_contexts=[], override_options={}, options={})
       raise ArgumentError, "Missing chef role" unless role
       raise ArgumentError, "Missing chef environment" unless environment
       allow_empty_roles = options.fetch(:allow_empty_roles, false)
@@ -54,6 +54,15 @@ module Stemcell
       role_empty   = role_options.nil? || role_options.empty?
 
       raise EmptyRoleError if !allow_empty_roles && role_empty
+
+      # Step 1.5: Override context specific values
+      if !role_empty
+        context_overrides = role_options['context_overrides'] || {}
+        override_contexts.each { |context|
+          overriding_hash = context_overrides[context]
+          role_options.merge!(overriding_hash) if overriding_hash
+        }
+      end
 
       # Step 2: Determine the backing store from available options.
 

--- a/lib/stemcell/option_parser.rb
+++ b/lib/stemcell/option_parser.rb
@@ -260,6 +260,12 @@ module Stemcell
         :type  => nil,
         :env   => 'NON_INTERACTIVE',
         :short => :f
+      },
+      {
+        :name  => 'contexts',
+        :desc  => "comma-separated list of contexts to override certain values",
+        :type  => String,
+        :env   => "CONTEXTS",
       }
     ]
 

--- a/lib/stemcell/version.rb
+++ b/lib/stemcell/version.rb
@@ -1,3 +1,3 @@
 module Stemcell
-  VERSION = "0.10.1"
+  VERSION = "0.11.0"
 end

--- a/spec/lib/stemcell/metadata_source_spec.rb
+++ b/spec/lib/stemcell/metadata_source_spec.rb
@@ -212,14 +212,18 @@ describe Stemcell::MetadataSource do
         end
 
         context "when context overrides" do
-          before {override_contexts << 'another_account'}
-          before {
+          before do
+            override_contexts << 'another_account'
             role_metadata.merge!({'security_groups' => 'default_group'})
             role_metadata.merge!({'context_overrides' => {'another_account' => {'security_groups' => 'another_group'}}})
-          }
+          end
 
           it 'returns the overrode security groups' do
             expect(expansion['security_groups']).to eql 'another_group'
+          end
+
+          it 'delete "context_overrides" key from Chef options' do
+            expect(expansion).not_to have_key('context_overrides')
           end
         end
 

--- a/spec/lib/stemcell/metadata_source_spec.rb
+++ b/spec/lib/stemcell/metadata_source_spec.rb
@@ -64,6 +64,7 @@ describe Stemcell::MetadataSource do
     let(:backing_options)    { Hash.new }
     let(:availability_zones) { Hash.new }
     let(:role_metadata)      { Hash.new }
+    let(:override_contexts)  { Array.new }
     let(:override_options)   { Hash.new }
     let(:expand_options)     { Hash.new }
 
@@ -81,6 +82,7 @@ describe Stemcell::MetadataSource do
       metadata_source.expand_role(
         role,
         environment,
+        override_contexts,
         override_options,
         expand_options)
     end
@@ -206,6 +208,18 @@ describe Stemcell::MetadataSource do
 
           it "substitutes an availability zone from the config" do
             expect(expansion['availability_zone']).to eql 'us-east-1a'
+          end
+        end
+
+        context "when context overrides" do
+          before {override_contexts << 'another_account'}
+          before {
+            role_metadata.merge!({'security_groups' => 'default_group'})
+            role_metadata.merge!({'context_overrides' => {'another_account' => {'security_groups' => 'another_group'}}})
+          }
+
+          it 'returns the overrode security groups' do
+            expect(expansion['security_groups']).to eql 'another_group'
           end
         end
 


### PR DESCRIPTION
This adds the ability in `metdata_source` to takes in a list of contexts, as well as a new command line parameter `--contexts`, to override instance_metadata.

## Example:

When you need to deal with managing several contexts (aws accounts, regions, environments, etc.) from the same Chef repo, you can have context specific attributes that overrides in a given context. The format in Chef's role file looks like this:

```
default_attributes({
  "instance_metadata" => {
    "security_groups" => ["default_group"],
    "context_overrides" => {
      "account_1" => {
        "security_groups" => ["acc1_group"],
      },
      "account_2" => {
        "security_groups" => ["acc2_group"],
      },
    },
  }
})
```

## Usage:

Originally calling
> `metadata_source#expand_role(role, environment, override_options, options)` 

gives you `{"security_groups" => ["default_group"] }`.


Now you can call 
> `metadata_source#expand_role(role, environment, ["account_1"], override_options, options)`

to get value under account_1: `{"security_groups" => "acc1_group"}`.


In command line usage, using the new parameter `--contexts=account_1` has the same effect. 

@jtai  @josephsofaer 