### PR TITLE
bootstrap.sh updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.11.1
+- update bootstrap.sh to support launched_by file, site-cookbooks, ohai_plugins, and retries if the initial converge fails
+- include version in version string
+
 # 0.11.0
 - allow user to specify `contexts` to override certain attributes
 

--- a/lib/stemcell/command_line.rb
+++ b/lib/stemcell/command_line.rb
@@ -8,7 +8,7 @@ module Stemcell
     attr_reader :chef_root
     attr_reader :chef_role
 
-    VERSION_STRING = "Stemcell (c) 2012-2013 Airbnb."
+    VERSION_STRING = "Stemcell #{VERSION} (c) 2012-2016 Airbnb."
     BANNER_STRING  = "Launch instances from metadata stored in roles!\n" \
                      "Usage: stemcell [chef role] [options]"
 

--- a/lib/stemcell/templates/bootstrap.sh.erb
+++ b/lib/stemcell/templates/bootstrap.sh.erb
@@ -204,9 +204,27 @@ EOF
 
 
 run_chef() {
-  echo "doing initial chef run..."
-  $converge 1>&2
-  echo "initial chef run complete"
+  set +e # unset e to allow retries
+  converge_succeed=false
+  for atmpt in $(seq 1 3);
+  do
+    echo "doing initial chef run... (attempt $atmpt)"
+    $converge 1>&2
+    if [ $? -eq 0 ]; then
+      converge_succeed=true
+      break
+    fi
+  done
+
+  if [ $converge_succeed == true ]; then
+    echo "initial chef run completes successfully"
+  else
+    echo "****************************************"
+    echo "*  WARNING: initial converge failed!   *"
+    echo "****************************************"
+  fi
+
+  set -e
 }
 
 

--- a/lib/stemcell/templates/bootstrap.sh.erb
+++ b/lib/stemcell/templates/bootstrap.sh.erb
@@ -152,7 +152,7 @@ configure_chef() {
   echo "configuring chef solo..."
   cat<<EOF > ${chef_dir}/solo.rb
 repo_dir =    "${repo_dir}"
-cookbook_path "#{repo_dir}/cookbooks"
+cookbook_path ["#{repo_dir}/site-cookbooks", "#{repo_dir}/cookbooks"]
 role_path     "#{repo_dir}/roles"
 data_bag_path "#{repo_dir}/data_bags"
 ssl_verify_mode :verify_peer

--- a/lib/stemcell/templates/bootstrap.sh.erb
+++ b/lib/stemcell/templates/bootstrap.sh.erb
@@ -1,12 +1,6 @@
 #!/bin/bash -e
 #
 # This script will bootstrap and run chef
-#
-# You need to specify a role, origin, git_key, branch name, and data
-# bag secret info below
-#
-# Martin Rhoads
-
 
 (
 echo 'Acquiring converge lock...'
@@ -16,13 +10,11 @@ echo 'Lock acquired!'
 set -o pipefail
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-
 # ensure we were called by root
 if [ $UID != 0 ]; then
   echo "this script needs to be run as root. exiting..."
   exit 1
 fi
-
 
 # redirect stdout to /var/log/init
 exec >> /var/log/init
@@ -36,6 +28,14 @@ exec 2>> /var/log/init.err
 ##
 
 chef_dir=/etc/chef
+repo_dir=${chef_dir}/src
+keyfile=${chef_dir}/git_key
+envfile=${chef_dir}/environment
+launchedbyfile=${chef_dir}/launched_by
+rolefile=${chef_dir}/role
+branchfile=${chef_dir}/branch
+originfile=${chef_dir}/origin
+git_wrapper=${chef_dir}/git_wrapper
 converge=/usr/local/bin/first_converge
 role=<%= opts['chef_role'] %>
 environment=<%= opts['chef_environment'] %>
@@ -50,15 +50,13 @@ username='<%= opts.fetch('user', ENV['USER']) %>'
 
 
 ##
-## common function
+## common functions
 ##
-
 
 update() {
   echo updating apt repo
   apt-get update 1>&2
 }
-
 
 install() {
   if ! (dpkg -l | awk '{print $2}' | grep -q ^$1$ ) ; then
@@ -67,7 +65,6 @@ install() {
     apt-get install -y $1 1>&2
   fi
 }
-
 
 set_hostname() {
   instance_id=`curl --silent --retry 5 --retry-delay 5 169.254.169.254/latest/meta-data/instance-id` 1>&2
@@ -131,7 +128,6 @@ update_repo() {
   echo "done updating code"
 }
 
-
 configure_chef() {
   echo "saving current origin ($origin), branch ($branch), role ($role), and environment ($environment)"
   echo "$origin" > $originfile
@@ -168,8 +164,7 @@ EOF
   echo "chef configured"
 }
 
-
-configure_converger() {
+configure_converge() {
   cat<<EOF > $converge
 #!/bin/bash -eu
 
@@ -202,7 +197,6 @@ EOF
   chmod 544 $converge
 }
 
-
 run_chef() {
   set +e # unset e to allow retries
   converge_succeed=false
@@ -232,18 +226,7 @@ run_chef() {
 ## main
 ##
 
-#some derived vars
-repo_dir=${chef_dir}/src
-keyfile=${chef_dir}/git_key
-envfile=${chef_dir}/environment
-launchedbyfile=${chef_dir}/launched_by
-rolefile=${chef_dir}/role
-branchfile=${chef_dir}/branch
-originfile=${chef_dir}/origin
-git_wrapper=${chef_dir}/git_wrapper
-
 echo "starting chef bootstrapping..."
-mkdir -p ${chef_dir}
 update
 install curl
 install git
@@ -252,13 +235,7 @@ install_chef
 create_ohai_hint
 update_repo
 configure_chef
-configure_converger
+configure_converge
 run_chef
-
-##
-## exit
-##
-
-
 echo "<%= last_bootstrap_line %>"
 ) 200> /var/run/converge.lock

--- a/lib/stemcell/templates/bootstrap.sh.erb
+++ b/lib/stemcell/templates/bootstrap.sh.erb
@@ -46,6 +46,7 @@ data_bag_secret='<%= opts["chef_data_bag_secret"] %>'
 hostname='<%= opts['instance_hostname'] %>'
 domain_name='<%= opts['instance_domain_name'] %>'
 chef_version='<%= opts['chef_version'] %>'
+username='<%= opts.fetch('user', ENV['USER']) %>'
 
 
 ##
@@ -145,6 +146,9 @@ configure_chef() {
   echo "$environment" > $envfile
   chmod 644 $envfile
 
+  echo "$username" > $launchedbyfile
+  chmod 644 $launchedbyfile
+
   echo "configuring chef solo..."
   cat<<EOF > ${chef_dir}/solo.rb
 repo_dir =    "${repo_dir}"
@@ -230,6 +234,7 @@ start_chef_daemon() {
 repo_dir=${chef_dir}/src
 keyfile=${chef_dir}/git_key
 envfile=${chef_dir}/environment
+launchedbyfile=${chef_dir}/launched_by
 rolefile=${chef_dir}/role
 branchfile=${chef_dir}/branch
 originfile=${chef_dir}/origin

--- a/lib/stemcell/templates/bootstrap.sh.erb
+++ b/lib/stemcell/templates/bootstrap.sh.erb
@@ -147,14 +147,16 @@ configure_chef() {
 
   echo "configuring chef solo..."
   cat<<EOF > ${chef_dir}/solo.rb
-repo_dir =    "${repo_dir}"
+repo_dir = "${repo_dir}"
+
 cookbook_path ["#{repo_dir}/site-cookbooks", "#{repo_dir}/cookbooks"]
-role_path     "#{repo_dir}/roles"
+role_path "#{repo_dir}/roles"
 data_bag_path "#{repo_dir}/data_bags"
 ssl_verify_mode :verify_peer
+log_level :info
+log_location STDOUT
 
-log_level        :info
-log_location     STDOUT
+Ohai::Config[:plugin_path] << "#{repo_dir}/ohai_plugins"
 EOF
 
   encrypted_data_bag_secret_file=${chef_dir}/encrypted_data_bag_secret

--- a/lib/stemcell/templates/bootstrap.sh.erb
+++ b/lib/stemcell/templates/bootstrap.sh.erb
@@ -202,27 +202,11 @@ EOF
   chmod 544 $converge
 }
 
-configure_chef_daemon() {
-  cat<<EOF > /etc/init/chef-solo.conf
-description     "chef-solo"
-author          "Martin Rhoads"
-start on networking
-script
-chef-solo --interval 600 --splay 600  | logger -t chef-solo 2>&1
-end script
-respawn
-EOF
-}
-
 
 run_chef() {
   echo "doing initial chef run..."
   $converge 1>&2
   echo "initial chef run complete"
-}
-
-start_chef_daemon() {
-  start chef-solo
 }
 
 
@@ -252,10 +236,6 @@ update_repo
 configure_chef
 configure_converger
 run_chef
-
-configure_chef_daemon
-# start_chef_daemon
-
 
 ##
 ## exit

--- a/lib/stemcell/version.rb
+++ b/lib/stemcell/version.rb
@@ -1,3 +1,3 @@
 module Stemcell
-  VERSION = "0.11.0"
+  VERSION = "0.11.1"
 end


### PR DESCRIPTION
This pull request includes a few additions and cleanups to the bootstrap.sh template:

 * Add launched_by file
 * Support site-cookbooks
 * Remove unused chef daemon functions
 * Retry initial converge on failure
 * Cosmetic whitespace changes and reordering
 * Add `ohai_plugins` to the Ohai plugin path

It also adds the version to the version string and bumps the gem version to 0.11.1.

@alexism @tuckerman @ziliangpeng @josephsofaer 