### PR TITLE
add --legacy-mode if >= chef 12.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.11.3
+- add legacy-mode flag to bootstrap.sh.erb when launching Chef 12.11 or newer
+
 # 0.11.2
 - fix undefined VERSION constant
 

--- a/lib/stemcell/templates/bootstrap.sh.erb
+++ b/lib/stemcell/templates/bootstrap.sh.erb
@@ -194,7 +194,11 @@ echo \$json > \$json_file
 trap "{ rm -f '\$json_file' ; }" EXIT
 
 echo "running chef-solo with runlist \$runlist and json \$json (in file \$json_file)"
+<% if opts['chef_version'].to_f >= 12.11 %>
+chef-solo --legacy-mode -o "\${runlist}" -j \${json_file} "\$@"
+<% else %>
 chef-solo -o "\${runlist}" -j \${json_file} "\$@"
+<% end %>
 EOF
   chmod 544 $converge
 }

--- a/lib/stemcell/version.rb
+++ b/lib/stemcell/version.rb
@@ -1,3 +1,3 @@
 module Stemcell
-  VERSION = "0.11.2"
+  VERSION = "0.11.3"
 end


### PR DESCRIPTION
to @josephsofaer @jtai 
cc @ziliangpeng 

To bootstrap nodes to Chef 12.12, the `--legacy-mode` flag must be added to `chef-solo` to avoid running chef-zero.  If the launch opts contain at least 12.11 or higher, the flag is added to the `chef-solo` run in the `first_converge` script.