### PR TITLE
Support for Chef cookbook/normal attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ rvm:
   - 2.1.2
   - 2.2.4
   - 2.3.1
+before_install:
+  - gem install bundler

--- a/lib/stemcell/metadata_source.rb
+++ b/lib/stemcell/metadata_source.rb
@@ -48,13 +48,15 @@ module Stemcell
       raise ArgumentError, "Missing chef environment" unless environment
       allow_empty_roles = options.fetch(:allow_empty_roles, false)
 
-      # Cookbook attribute files to load during role metadata expansion
+      # Normal and cookbook attributes to load during role metadata expansion
+      normal_attributes     = options.fetch(:normal_attributes, {})
       cookbook_attributes   = override_options['chef_cookbook_attributes']
       cookbook_attributes ||= config.default_options['chef_cookbook_attributes']
       cookbook_attributes ||= []
 
       chef_options = {}
       chef_options[:cookbook_attributes] = cookbook_attributes unless cookbook_attributes.empty?
+      chef_options[:normal_attributes] = normal_attributes unless normal_attributes.empty?
 
       # Step 1: Expand the role metadata
       role_options = chef_repo.metadata_for_role(role, environment, chef_options)

--- a/lib/stemcell/metadata_source.rb
+++ b/lib/stemcell/metadata_source.rb
@@ -48,9 +48,16 @@ module Stemcell
       raise ArgumentError, "Missing chef environment" unless environment
       allow_empty_roles = options.fetch(:allow_empty_roles, false)
 
-      # Step 1: Expand the role metadata
+      # Cookbook attribute files to load during role metadata expansion
+      cookbook_attributes   = override_options['chef_cookbook_attributes']
+      cookbook_attributes ||= config.default_options['chef_cookbook_attributes']
+      cookbook_attributes ||= []
 
-      role_options = chef_repo.metadata_for_role(role, environment)
+      chef_options = {}
+      chef_options[:cookbook_attributes] = cookbook_attributes unless cookbook_attributes.empty?
+
+      # Step 1: Expand the role metadata
+      role_options = chef_repo.metadata_for_role(role, environment, chef_options)
       role_empty   = role_options.nil? || role_options.empty?
 
       raise EmptyRoleError if !allow_empty_roles && role_empty

--- a/lib/stemcell/metadata_source/chef_repository.rb
+++ b/lib/stemcell/metadata_source/chef_repository.rb
@@ -43,6 +43,9 @@ module Stemcell
         node.chef_environment = chef_environment
         node.run_list << "role[#{chef_role}]"
 
+        normal_attributes = chef_options.fetch(:normal_attributes, {})
+        node.consume_attributes(normal_attributes)
+
         # Load cookbooks.
         cookbook_loader = Chef::CookbookLoader.new(Chef::Config[:cookbook_path])
         cookbook_attributes = chef_options.fetch(:cookbook_attributes, [])

--- a/lib/stemcell/option_parser.rb
+++ b/lib/stemcell/option_parser.rb
@@ -218,6 +218,12 @@ module Stemcell
         :env   => 'CHEF_ENVIRONMENT'
       },
       {
+        :name  => 'chef_cookbook_attributes',
+        :desc  => "comma-separated list of cookbook attribute files to load during role expansion",
+        :type  => String,
+        :env   => 'CHEF_COOKBOOK_ATTRIBUTES'
+      },
+      {
         :name  => 'git_origin',
         :desc  => "git origin to use",
         :type  => String,
@@ -401,6 +407,8 @@ module Stemcell
       options['security_group_ids'] &&= options['security_group_ids'].split(',')
       # convert ephemeral_devices from comma separated string to ruby array
       options['ephemeral_devices'] &&= options['ephemeral_devices'].split(',')
+      # convert chef_cookbook_attributes from comma separated string to ruby array
+      options['chef_cookbook_attributes'] &&= options['chef_cookbook_attributes'].split(',')
 
       # format the classic link options
       if options['classic_link_vpc_id']

--- a/spec/fixtures/chef_repo/cookbooks/unit_cookbook/attributes/simple-default.rb
+++ b/spec/fixtures/chef_repo/cookbooks/unit_cookbook/attributes/simple-default.rb
@@ -1,0 +1,4 @@
+default['instance_metadata']['tags'] = {
+  'tag1' => 'tag1_value_attribute_default',
+  'tag3' => 'tag3_value_attribute_default',
+}

--- a/spec/fixtures/chef_repo/cookbooks/unit_cookbook/attributes/simple-derived.rb
+++ b/spec/fixtures/chef_repo/cookbooks/unit_cookbook/attributes/simple-derived.rb
@@ -1,0 +1,3 @@
+default['instance_metadata']['tags'] = { 'tag1' => 'tag1_value_attribute_default' }
+tag1 = node['instance_metadata']['tags']['tag1']
+default['instance_metadata']['tags']['derived_tag1'] = tag1

--- a/spec/fixtures/chef_repo/cookbooks/unit_cookbook/attributes/simple-override.rb
+++ b/spec/fixtures/chef_repo/cookbooks/unit_cookbook/attributes/simple-override.rb
@@ -1,0 +1,1 @@
+override['instance_metadata']['tags']['tag2'] = 'tag2_value_override'

--- a/spec/fixtures/chef_repo/cookbooks/unit_cookbook/metadata.rb
+++ b/spec/fixtures/chef_repo/cookbooks/unit_cookbook/metadata.rb
@@ -1,0 +1,1 @@
+name             'unit_cookbook'

--- a/spec/fixtures/chef_repo/stemcell-cookbook-attribute.json
+++ b/spec/fixtures/chef_repo/stemcell-cookbook-attribute.json
@@ -1,0 +1,14 @@
+{
+  "defaults": {
+    "instance_type": "m1.small",
+    "chef_cookbook_attributes": ["cookbook_name::attr_file"]
+  },
+  "backing_store": {
+    "instance_store": {
+      "image_id": "ami-d9d6a6b0"
+    }
+  },
+  "availability_zones": {
+    "us-east-1": ["us-east-1a"]
+  }
+}

--- a/spec/lib/stemcell/metadata_source/chef_repository_spec.rb
+++ b/spec/lib/stemcell/metadata_source/chef_repository_spec.rb
@@ -36,7 +36,13 @@ describe Stemcell::MetadataSource::ChefRepository do
     let(:result_metadata)   { chef_repo.metadata_for_role(role, environment, options) }
 
     let(:cookbook_attributes) { [] }
-    let(:options) { { :cookbook_attributes => cookbook_attributes } }
+    let(:normal_attributes) { {} }
+    let(:options) {
+      {
+        :cookbook_attributes => cookbook_attributes,
+        :normal_attributes => normal_attributes
+      }
+    }
     let(:environment) { 'production' }
     let(:role) { nil }
 
@@ -150,6 +156,41 @@ describe Stemcell::MetadataSource::ChefRepository do
             "tags" => {
               "tag1" => "tag1_value_default",
               "tag2" => "tag2_value_override"
+            }
+          )
+        end
+      end
+
+    end
+
+    context "with normal attributes" do
+      let(:role) { 'unit-simple-default' }
+
+      context "for a role with default attribute" do
+        let(:normal_attributes) { { :instance_metadata => { :instance_type => 'test' } } }
+        it "returns the attribute with higher precedence" do
+          expect(result_metadata).to include("instance_type" => "test")
+        end
+      end
+
+      context "for a cookbook attribute" do
+        let(:role) { 'unit-simple-default' }
+        let(:cookbook_attributes) { ['unit_cookbook::simple-derived'] }
+        let(:normal_attributes) {
+          {
+            :instance_metadata => {
+              :tags => {
+                'tag1' => 'tag1_value_normal'
+              }
+            }
+          }
+        }
+        it "returns the normal/derived attribute" do
+          expect(result_metadata).to include(
+            "tags" => {
+              "tag1" => "tag1_value_normal",
+              "derived_tag1" => "tag1_value_normal",
+              "tag2" => "tag2_value"
             }
           )
         end

--- a/spec/lib/stemcell/metadata_source/configuration_spec.rb
+++ b/spec/lib/stemcell/metadata_source/configuration_spec.rb
@@ -44,6 +44,16 @@ describe Stemcell::MetadataSource::Configuration do
       end
     end
 
+    context "when non-required options are present" do
+      let(:config_filename) { 'stemcell-cookbook-attribute.json' }
+      it "sets default_options" do
+        expect(config.default_options).to eql({
+          'instance_type' => 'm1.small',
+          'chef_cookbook_attributes' => ['cookbook_name::attr_file']
+        })
+      end
+    end
+
     context "when defaults are not specified" do
       let(:config_filename) { 'stemcell-defaults-missing.json' }
       it "raises" do

--- a/spec/lib/stemcell/metadata_source_spec.rb
+++ b/spec/lib/stemcell/metadata_source_spec.rb
@@ -243,6 +243,14 @@ describe Stemcell::MetadataSource do
           end
         end
 
+        context 'when the expand options specify chef normal attributes' do
+          before { expand_options[:normal_attributes] = { :a => :b } }
+          it 'is the value in the expand options' do
+            expect(chef_repo).to receive(:metadata_for_role).with(role, environment, expand_options) { role_metadata }
+            expect(expansion).to_not be_nil
+          end
+        end
+
       end
 
     end

--- a/spec/lib/stemcell/metadata_source_spec.rb
+++ b/spec/lib/stemcell/metadata_source_spec.rb
@@ -167,7 +167,7 @@ describe Stemcell::MetadataSource do
 
         it "calls the repository object to determine the role metadata" do
           role_metadata.merge!('image_id' => 'ami-nyancat')
-          expect(chef_repo).to receive(:metadata_for_role).with(role, environment) { role_metadata }
+          expect(chef_repo).to receive(:metadata_for_role).with(role, environment, {}) { role_metadata }
           expect(expansion['image_id']).to eql 'ami-nyancat'
         end
 
@@ -224,6 +224,22 @@ describe Stemcell::MetadataSource do
 
           it 'delete "context_overrides" key from Chef options' do
             expect(expansion).not_to have_key('context_overrides')
+          end
+        end
+
+        it "calls the config object to retrieve chef cookbook attributes" do
+          default_options.merge!('chef_cookbook_attributes' => ['a::b'])
+          expect(config).to receive(:default_options) { default_options }
+          expect(expansion['chef_cookbook_attributes']).to eql ['a::b']
+        end
+
+        context 'when the override options specify chef cookbook attributes' do
+          let(:options) { { :cookbook_attributes => ['c::d'] } }
+          it 'is the value in the override options' do
+            default_options.merge!('chef_cookbook_attributes' => ['a::b'])
+            override_options.merge!('chef_cookbook_attributes' => ['c::d'])
+            expect(chef_repo).to receive(:metadata_for_role).with(role, environment, options) { role_metadata }
+            expect(expansion['chef_cookbook_attributes']).to eql ['c::d']
           end
         end
 


### PR DESCRIPTION
Allow cookbook and normal attributes to be specified for role expansion. This makes the role expansion behave more like a regular Chef run and for cookbook attributes to react to and produce attributes.

The use case is to allow for normal attributes to be set before role expansion and have a cookbook attribute produce derived attributes. Since a normal attribute has a higher attribute precedence than a default attribute, these effectively work as overrides that are available during expansion. For example, if expansion is invoked with an `account` attribute, a cookbook attribute file can be used to set `instance_metadata` attributes that are derived from the `account` attribute.

@noggi @jimmyngo @tuckerman