### PR TITLE
Result of role expansion needs to be a mutable object

### DIFF
--- a/lib/stemcell/metadata_source/chef_repository.rb
+++ b/lib/stemcell/metadata_source/chef_repository.rb
@@ -71,7 +71,7 @@ module Stemcell
           node.include_attribute(file_spec)
         end
 
-        node.attributes
+        Mash.new(node.attributes.to_hash)
       end
 
     end


### PR DESCRIPTION
In order for context overrides to be merged into the resulting hash from role expansion.