### PR TITLE
[launcher] Allow classic link to associate VPC security groups by name

### DIFF
--- a/lib/stemcell/option_parser.rb
+++ b/lib/stemcell/option_parser.rb
@@ -103,6 +103,12 @@ module Stemcell
         :env   => 'CLASSIC_LINK_SECURITY_GROUP_IDS',
       },
       {
+        :name  => 'classic_link_security_groups',
+        :desc  => 'comma-separated list of security groups to link into ClassicLink; not used unless classic_link_vpc_id is set',
+        :type  => String,
+        :env   => 'CLASSIC_LINK_SECURITY_GROUPS',
+      },
+      {
         :name  => 'subnet',
         :desc  => "VPC subnet for which to launch this instance",
         :type  => String,
@@ -415,7 +421,10 @@ module Stemcell
         options['classic_link']['vpc_id'] = options['classic_link_vpc_id']
       end
       if options['classic_link_security_group_ids']
-        options['classic_link']['security_group_ids'] = options['classic_link_security_group_ids']
+        options['classic_link']['security_group_ids'] = options['classic_link_security_group_ids'].split(',')
+      end
+      if options['classic_link_security_groups']
+        options['classic_link']['security_groups'] = options['classic_link_security_groups'].split(',')
       end
 
       options


### PR DESCRIPTION
Add a new `security_groups` field to `classic_link`, which should contain an array of VPC security groups to associate with a classic instance. If specified, the security group names are resolved to their ids in the given VPC.