### PR TITLE
[launcher] Convert security group names to ids when launching VPC instances

### DIFF
--- a/lib/stemcell/launcher.rb
+++ b/lib/stemcell/launcher.rb
@@ -106,12 +106,19 @@ module Stemcell
         :count => opts['count'],
       }
 
-      if opts['security_groups'] && !opts['security_groups'].empty?
-        launch_options[:security_groups] = opts['security_groups']
-      end
-
       if opts['security_group_ids'] && !opts['security_group_ids'].empty?
         launch_options[:security_group_ids] = opts['security_group_ids']
+      end
+
+      if opts['security_groups'] && !opts['security_groups'].empty?
+        if @vpc_id
+          # convert sg names to sg ids as VPC only accepts ids
+          security_group_ids = get_vpc_security_group_ids(@vpc_id, opts['security_groups'])
+          launch_options[:security_group_ids] ||= []
+          launch_options[:security_group_ids].concat(security_group_ids)
+        else
+          launch_options[:security_groups] = opts['security_groups']
+        end
       end
 
       # specify availability zone (optional)


### PR DESCRIPTION
When launching an instance in VPC, if any security groups are specified by name, AWS's SDK will convert the security group names to ids as the VPC instance API only accepts security group ids. This conversion is accomplished by looking for the security group names across all security groups (including classic and VPCs, see [security_group_opts](https://github.com/aws/aws-sdk-ruby/blob/v1.63.0/lib/aws/ec2/instance_collection.rb#L386)).

The problem is that if there are multiple security groups with the same name, the name will be converted to the ids of all security groups with said name, irregardless of whether these security groups are in the same VPC (where the instance is being launched) or not. In such case, launching the instance will fail with `The security group 'sg-id' does not exist in VPC 'vpc-id'`.

To work around this limitation, this change implements the conversion within stemcell in such way that it only looks for security groups in the VPC where the instance is being launched.