### PR TITLE
Configure AWS earlier to work around aws-sdk-v1 vpc bug

### DIFF
--- a/lib/stemcell/launcher.rb
+++ b/lib/stemcell/launcher.rb
@@ -78,6 +78,7 @@ module Stemcell
       @aws_access_key = opts['aws_access_key']
       @aws_secret_key = opts['aws_secret_key']
       @aws_session_token = opts['aws_session_token']
+      configure_aws_creds_and_region
     end
 
     def launch(opts={})
@@ -429,17 +430,6 @@ module Stemcell
     def ec2
       return @ec2 if @ec2
 
-      # configure AWS with creds/region
-      aws_configs = {:region => @region}
-      aws_configs.merge!({
-        :access_key_id     => @aws_access_key,
-        :secret_access_key => @aws_secret_key
-      }) if @aws_access_key && @aws_secret_key
-      aws_configs.merge!({
-        :session_token     => @aws_session_token,
-      }) if @aws_session_token
-      AWS.config(aws_configs)
-
       # calculate our ec2 url
       ec2_url = "ec2.#{@region}.amazonaws.com"
 
@@ -459,6 +449,19 @@ module Stemcell
       else
         sleep [RUNNING_STATE_WAIT_SLEEP_TIME, times_out_at - now].min
       end
+    end
+
+    def configure_aws_creds_and_region
+      # configure AWS with creds/region
+      aws_configs = {:region => @region}
+      aws_configs.merge!({
+        :access_key_id     => @aws_access_key,
+        :secret_access_key => @aws_secret_key
+      }) if @aws_access_key && @aws_secret_key
+      aws_configs.merge!({
+        :session_token     => @aws_session_token,
+      }) if @aws_session_token
+      AWS.config(aws_configs)
     end
   end
 end

--- a/spec/lib/stemcell/launcher_spec.rb
+++ b/spec/lib/stemcell/launcher_spec.rb
@@ -156,4 +156,15 @@ describe Stemcell::Launcher do
       expect(errors.all?(&:nil?)).to be true
     end
   end
+
+  describe '#configure_aws_creds_and_region' do
+    it 'AWS region is configured after launcher is instanciated' do
+      expect(AWS.config.region).to be_eql('region')
+    end
+
+    it 'AWS region configuration changed' do
+      mock_launcher = Stemcell::Launcher.new('region' => 'ap-northeast-1')
+      expect(AWS.config.region).to be_eql('ap-northeast-1')
+    end
+  end
 end


### PR DESCRIPTION
## Summary
AWS-SDK-V1 has a bug in VPC class which ignores the options passed into the constructor https://github.com/aws/aws-sdk-ruby/blob/aws-sdk-v1/lib/aws/ec2/vpc.rb#L25. Therefore to get VPC in regions other than us-east-1 which is the default region, we have to set the global AWS configuration first before instantiate an VPC. Moving the configuration part into constructor to make sure any of the method in the Launcher class is working with the correct region.

## How was it tested?
Unit test.
Tested in Starforge CN host using IRB to get correct VPC.

cc
@darnaut 
