### PR TITLE
Transform chef_cookbook_attributes option for command-line parser

### DIFF
--- a/lib/stemcell/command_line.rb
+++ b/lib/stemcell/command_line.rb
@@ -125,13 +125,14 @@ module Stemcell
     end
 
     def transform_parser_defaults(pd)
-      # There are two special cases: security groups and tags. Security groups
+      # There are some special cases, eg security groups and tags. Security groups
       # are an array in the template, but trollop expects a string. Likewise,
       # in the case of tags, they are represented as a hash, but trollop wants
       # a string once again. In both cases, the data types are encoded as a
       # comma-separated list when presented as defaults.
       pd['security_groups'] &&= pd['security_groups'].join(',')
       pd['tags'] &&= pd['tags'].to_a.map { |p| p.join('=') }.join(',')
+      pd['chef_cookbook_attributes'] &&= pd['chef_cookbook_attributes'].join(',')
     end
 
     def parse_options_or_print_help

--- a/spec/fixtures/chef_repo/stemcell-options-parser.json
+++ b/spec/fixtures/chef_repo/stemcell-options-parser.json
@@ -1,0 +1,29 @@
+{
+  "defaults": {
+    "region": "us-east-1",
+    "security_groups": ["sg1", "sg2"],
+    "instance_type": "m1.small",
+    "backing_store": "hvm1",
+    "git_origin": "git1",
+    "instance_domain_name": "example.com",
+    "chef_package_source": "https://example.com/chef.deb",
+    "chef_version": "12.12.15-1",
+    "chef_cookbook_attributes": ["name::attribute"],
+    "tags": {
+      "tag1": "value"
+    }
+  },
+
+  "backing_store": {
+    "hvm1": {
+      "image_id": "ami-1"
+    },
+    "pv1": {
+      "image_id": "ami-2"
+    }
+  },
+
+  "availability_zones": {
+    "us-east-1": ["us-east-1a", "us-east-1b", "us-east-1c", "us-east-1e"]
+  }
+}

--- a/spec/lib/stemcell/command_line_spec.rb
+++ b/spec/lib/stemcell/command_line_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Stemcell::CommandLine do
+  describe '#run!' do
+    let(:chef_root) { FixtureHelper.chef_repo_fixture_path }
+    let(:config_fn) { 'Stemcell::MetadataSource::DEFAULT_CONFIG_FILENAME' }
+    it 'outputs a help message' do
+      stub_const 'ARGV', ["--local-chef-root=#{chef_root}", "--help"]
+      stub_const config_fn, 'stemcell-options-parser.json'
+      expect do
+        subject.run!
+      end.to output(/Show this message/).to_stdout.and raise_error(SystemExit)
+    end
+  end
+end


### PR DESCRIPTION
Fixes `stemcell` command-line when config file includes a `chef_cookbook_attributes` option.