### PR TITLE
Set vpc_id when creating Launcher object

### DIFF
--- a/lib/stemcell/metadata_launcher.rb
+++ b/lib/stemcell/metadata_launcher.rb
@@ -99,6 +99,7 @@ module Stemcell
         'aws_secret_key'    => options['aws_secret_key'],
         'aws_session_token' => options['aws_session_token'],
         'region'            => options['region'],
+        'vpc_id'            => options['vpc_id'],
       })
       # Slice off just the options used for launching.
       launch_options = {}


### PR DESCRIPTION
VPC Id is used in a few places in Launcher class, but it's never passed from command line/options. This change is supposed to fix this issue.

@darnaut 