### PR TITLE
Do not set set_classic_link on vpc instances.

### DIFF
--- a/lib/stemcell/launcher.rb
+++ b/lib/stemcell/launcher.rb
@@ -195,8 +195,10 @@ module Stemcell
         @log.info "sent ec2 api tag requests successfully"
 
         # link to classiclink
-        set_classic_link(instances, opts['classic_link'])
-        @log.info "successfully applied classic link settings (if any)"
+        if @vpc_id.nil?
+          set_classic_link(instances, opts['classic_link'])
+          @log.info "successfully applied classic link settings (if any)"
+        end
 
         # turn on termination protection
         # we do this now to make sure all other settings worked

--- a/spec/lib/stemcell/launcher_spec.rb
+++ b/spec/lib/stemcell/launcher_spec.rb
@@ -86,6 +86,8 @@ describe Stemcell::Launcher do
           :user_data          => 'template'
         )).and_return(instances)
       expect(launcher).to receive(:set_tags).with(kind_of(Array), kind_of(Hash)).and_return(nil)
+      # set_classic_link should not be set on vpc hosts.
+      expect(launcher).not_to receive(:set_classic_link)
 
       launcher.send(:launch, launch_options)
     end


### PR DESCRIPTION
set_classic_link on vpc instances fail. Do not set it.

Tests:

All tests pass.