### PR TITLE
Fix set_classic_link issue  - vpc_id could be nil or false

### DIFF
--- a/lib/stemcell/launcher.rb
+++ b/lib/stemcell/launcher.rb
@@ -195,7 +195,7 @@ module Stemcell
         @log.info "sent ec2 api tag requests successfully"
 
         # link to classiclink
-        if @vpc_id.nil?
+        unless @vpc_id
           set_classic_link(instances, opts['classic_link'])
           @log.info "successfully applied classic link settings (if any)"
         end

--- a/spec/lib/stemcell/launcher_spec.rb
+++ b/spec/lib/stemcell/launcher_spec.rb
@@ -91,6 +91,14 @@ describe Stemcell::Launcher do
 
       launcher.send(:launch, launch_options)
     end
+
+    it 'calls set_classic_link for non vpc instances' do
+      launcher = Stemcell::Launcher.new({'region' => 'region', 'vpc_id' => false})
+      expect(launcher).to receive(:set_classic_link)
+      expect(launcher).to receive(:set_tags).with(kind_of(Array), kind_of(Hash)).and_return(nil)
+      expect(launcher).to receive(:do_launch).and_return(instances)
+      launcher.send(:launch, launch_options)
+    end
   end
 
   describe '#set_classic_link' do


### PR DESCRIPTION
Bug in : https://github.com/airbnb/stemcell/pull/90
@vpc_id is nil or false

Handle that case.

There is already a test for vpc.
New test for not vpc.

