### PR TITLE
Require nokogiri ~> 1.8.2 due to vulnerability in libxml2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 1.9.3
   - 2.1.2
   - 2.2.4
   - 2.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.12.0
+- Require Nokogiri ~> 1.8.2 due to vulnerability CVE-2017-15412
+- Require ruby version >= 2.1 for Nokogiri compatibility
+
 # 0.11.11
 - Fix set_classic_link issue - vpc_id could be nil or false
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,4 @@ group :test do
   gem 'rake', '~> 10.3.2'
 end
 
-gem 'nokogiri', '< 1.7.0'
+gem 'nokogiri', '~> 1.8.2'

--- a/lib/stemcell/version.rb
+++ b/lib/stemcell/version.rb
@@ -1,3 +1,3 @@
 module Stemcell
-  VERSION = "0.11.11"
+  VERSION = "0.12.0"
 end

--- a/stemcell.gemspec
+++ b/stemcell.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   # version dependency. lets explicitly include it here. if this becomes
   # no-longer a dependency of chef via chef-zero, then remove it
   s.add_runtime_dependency 'rack', '< 2.0.0'
-  s.add_runtime_dependency 'nokogiri', '< 1.7.0'
+  s.add_runtime_dependency 'nokogiri', '~> 1.8.2'
   s.add_runtime_dependency 'ffi-yajl', '< 2.3.1'
 
   s.add_runtime_dependency 'trollop',    '~> 2.1'


### PR DESCRIPTION
The version of libxml2 packaged with Nokogiri contains a vulnerability. Nokogiri has mitigated these issue by upgrading to libxml 2.9.6 in version 1.8.2

It was discovered that libxml2 incorrecty handled certain files. An attacker could use this issue with specially constructed XML data to cause libxml2 to consume resources, leading to a denial of service.

More info from Nokogiri repo: https://github.com/sparklemotion/nokogiri/issues/1714

We're also requiring ruby version >= 2.1 due to nokogiri