### PR TITLE
Ability to Clear Default Tags

### DIFF
--- a/lib/stemcell/launcher.rb
+++ b/lib/stemcell/launcher.rb
@@ -96,9 +96,14 @@ module Stemcell
         'created_by' => opts.fetch('user', ENV['USER']),
         'stemcell' => VERSION,
       }
+
       # Short name if we're in production
       tags['Name'] = opts['chef_role'] if opts['chef_environment'] == 'production'
       tags.merge!(opts['tags']) if opts['tags']
+
+      # Delete tags with nil value, as this isn't allowed by AWS
+      # (also makes it possible to clear/skip the defaults above)
+      tags.delete_if { |k, v| v.nil? }
 
       # generate launch options
       launch_options = {


### PR DESCRIPTION
This PR introduces two refinements around tags:

1. Use lower-case `group` instead of `Group`, to match other tag names (happy to skip this if you prefer).
2. Ability to clear/remove the default tags, by passing in a nil value.
3. [bonus] Guard against nil values in tags, since they are invalid in AWS anyways.

@darnaut Hi Davi! Happy to hear your thoughts on this!

I heard about the wildfire, hope you Californians are getting it under control! Sweden had a huge one about a month ago too, it's not fun. 🚒 

*(feel free to merge with the squash-and-merge option, to turn everything into one commit)*