### PR TITLE
Fix running under Chef 14.x

### DIFF
--- a/lib/stemcell/templates/bootstrap.sh.erb
+++ b/lib/stemcell/templates/bootstrap.sh.erb
@@ -233,7 +233,7 @@ trap "{ rm -f '\$json_file' ; }" EXIT
 
 echo "running chef-solo with runlist \$runlist and json \$json (in file \$json_file)"
 <% if opts['chef_version'].to_f >= 12.11 %>
-chef-solo --legacy-mode -o "\${runlist}" -j \${json_file} "\$@"
+chef-solo --config ${chef_dir}/solo.rb -o "\${runlist}" -j \${json_file} "\$@"
 <% else %>
 chef-solo -o "\${runlist}" -j \${json_file} "\$@"
 <% end %>


### PR DESCRIPTION
With 14.x we need to specify the config file explicitly, otherwise it won't be picked up.

The way this error manifests itself like is that with no config directory it will fall back to `~/.chef`, and the directory won't exist causing issues like this: https://github.com/airbnb/stemcell/issues/95

(it would also cause more trouble further into the chef run, but it doesn't get that far so the error we see is the one above)

Fixes #95 

