### PR TITLE
Node JSON support

### DIFF
--- a/lib/stemcell/launcher.rb
+++ b/lib/stemcell/launcher.rb
@@ -54,7 +54,8 @@ module Stemcell
       'termination_protection',
       'block_device_mappings',
       'ephemeral_devices',
-      'placement_group'
+      'placement_group',
+      'node_json',
     ]
 
     TEMPLATE_PATH = '../templates/bootstrap.sh.erb'
@@ -179,6 +180,14 @@ module Stemcell
             :virtual_name => "ephemeral#{i}"
           })
         end
+      end
+
+      if opts['node_json'].is_a?(Hash)
+        opts['node_json'] = JSON.generate(opts['node_json'])
+      end
+
+      unless opts['node_json'].is_a?(String)
+        opts['node_json'] = '{}'
       end
 
       # generate user data script to bootstrap instance, include in launch

--- a/lib/stemcell/launcher.rb
+++ b/lib/stemcell/launcher.rb
@@ -182,13 +182,15 @@ module Stemcell
         end
       end
 
-      if opts['node_json'].is_a?(Hash)
-        opts['node_json'] = JSON.generate(opts['node_json'])
+      unless opts['node_json'].is_a?(Hash) || opts['node_json'].nil?
+        raise '`node_json` must be a hash or nil'
       end
 
-      unless opts['node_json'].is_a?(String)
-        opts['node_json'] = '{}'
+      if opts['node_json'].nil?
+        opts['node_json'] = {}
       end
+
+      opts['node_json'] = JSON.generate(opts['node_json'])
 
       # generate user data script to bootstrap instance, include in launch
       # options UNLESS we have manually set the user-data (ie. for ec2admin)

--- a/lib/stemcell/launcher.rb
+++ b/lib/stemcell/launcher.rb
@@ -192,7 +192,7 @@ module Stemcell
 
       opts['node_json'].merge!({
         'role' => opts['chef_role'],
-        'env' => opts['chef_environment'],
+        'env' => opts['chef_environment'], # deprecated, use `node.chef_environment` in recipes instead
         'branch' => opts['git_branch'],
       })
 

--- a/lib/stemcell/launcher.rb
+++ b/lib/stemcell/launcher.rb
@@ -190,6 +190,12 @@ module Stemcell
         opts['node_json'] = {}
       end
 
+      opts['node_json'].merge!({
+        'role' => opts['chef_role'],
+        'env' => opts['chef_environment'],
+        'branch' => opts['git_branch'],
+      })
+
       opts['node_json'] = JSON.generate(opts['node_json'])
 
       # generate user data script to bootstrap instance, include in launch

--- a/lib/stemcell/templates/bootstrap.sh.erb
+++ b/lib/stemcell/templates/bootstrap.sh.erb
@@ -190,6 +190,7 @@ repo_dir = "${repo_dir}"
 cookbook_path ["#{repo_dir}/site-cookbooks", "#{repo_dir}/cookbooks"]
 role_path "#{repo_dir}/roles"
 data_bag_path "#{repo_dir}/data_bags"
+environment_path "#{repo_dir}/environments"
 ohai.plugin_path << "#{repo_dir}/ohai_plugins"
 ssl_verify_mode :verify_peer
 log_level :info
@@ -241,9 +242,9 @@ trap "{ rm -f '\$json_file' ; }" EXIT
 
 echo "running chef-solo with runlist \$runlist and json \$node_json (in file \$json_file)"
 <% if opts['chef_version'].to_f >= 12.11 %>
-chef-solo --legacy-mode -o "\${runlist}" -j \${json_file} "\$@"
+chef-solo --legacy-mode -o "\${runlist}" -j \${json_file} -E \${env} "\$@"
 <% else %>
-chef-solo -o "\${runlist}" -j \${json_file} "\$@"
+chef-solo -o "\${runlist}" -j \${json_file} -E \${env} "\$@"
 <% end %>
 EOF
   chmod 544 $converge

--- a/lib/stemcell/templates/bootstrap.sh.erb
+++ b/lib/stemcell/templates/bootstrap.sh.erb
@@ -31,6 +31,7 @@ chef_dir=/etc/chef
 repo_dir=${chef_dir}/src
 keyfile=${chef_dir}/git_key
 envfile=${chef_dir}/environment
+jsonfile=${chef_dir}/nodejson
 launchedbyfile=${chef_dir}/launched_by
 rolefile=${chef_dir}/role
 branchfile=${chef_dir}/branch
@@ -48,6 +49,7 @@ domain_name='<%= opts['instance_domain_name'] %>'
 chef_version='<%= opts['chef_version'] %>'
 username='<%= opts.fetch('user', ENV['USER']) %>'
 encrypted_data_bag_secret_path='<%= opts['chef_data_bag_secret_path'].to_s %>'
+node_json='<%= opts['node_json'] %>'
 
 ##
 ## common functions
@@ -158,7 +160,7 @@ update_repo() {
 }
 
 configure_chef() {
-  echo "saving current origin ($origin), branch ($branch), role ($role), and environment ($environment)"
+  echo "saving current origin ($origin), branch ($branch), role ($role), environment ($environment), and node_json ($node_json)"
   echo "$origin" > $originfile
   chmod 644 $originfile
 
@@ -173,6 +175,9 @@ configure_chef() {
 
   echo "$username" > $launchedbyfile
   chmod 644 $launchedbyfile
+
+  echo "$node_json" > $jsonfile
+  chmod 644 $jsonfile
 
   echo "configuring chef solo..."
   cat<<EOF > ${chef_dir}/solo.rb
@@ -212,6 +217,7 @@ repo="${repo_dir}"
 branch=\`cat ${branchfile}\`
 role=\`cat ${rolefile}\`
 env=\`cat ${envfile}\`
+node_json=\`cat ${jsonfile}\`
 
 cd \${repo}
 
@@ -226,7 +232,9 @@ GIT_SSH=${git_wrapper} git fetch
 git reset --hard origin/\${branch}
 git clean -fdx
 
-json="{\"role\": \"\${role}\", \"env\": \"\${env}\", \"branch\": \"\${branch}\"}"
+base_json="{\"role\": \"\${role}\", \"env\": \"\${env}\", \"branch\": \"\${branch}\"}"
+json=\`echo \$node_json \$base_json | jq -s '.[0] + .[1]'\`
+
 json_file=\`mktemp\`
 echo \$json > \$json_file
 trap "{ rm -f '\$json_file' ; }" EXIT
@@ -317,6 +325,7 @@ echo "starting chef bootstrapping on ${OS_VERSION}..."
 update
 install curl
 install git
+install jq
 set_hostname
 install_chef
 create_ohai_hint

--- a/lib/stemcell/templates/bootstrap.sh.erb
+++ b/lib/stemcell/templates/bootstrap.sh.erb
@@ -235,14 +235,11 @@ GIT_SSH=${git_wrapper} git fetch
 git reset --hard origin/\${branch}
 git clean -fdx
 
-base_json="{\"role\": \"\${role}\", \"env\": \"\${env}\", \"branch\": \"\${branch}\"}"
-json=\`echo \$node_json \$base_json | jq -s '.[0] + .[1]'\`
-
 json_file=\`mktemp\`
-echo \$json > \$json_file
+echo \$node_json > \$json_file
 trap "{ rm -f '\$json_file' ; }" EXIT
 
-echo "running chef-solo with runlist \$runlist and json \$json (in file \$json_file)"
+echo "running chef-solo with runlist \$runlist and json \$node_json (in file \$json_file)"
 <% if opts['chef_version'].to_f >= 12.11 %>
 chef-solo --legacy-mode -o "\${runlist}" -j \${json_file} "\$@"
 <% else %>
@@ -328,7 +325,6 @@ echo "starting chef bootstrapping on ${OS_VERSION}..."
 update
 install curl
 install git
-install jq
 set_hostname
 install_chef
 create_ohai_hint

--- a/lib/stemcell/templates/bootstrap.sh.erb
+++ b/lib/stemcell/templates/bootstrap.sh.erb
@@ -49,7 +49,10 @@ domain_name='<%= opts['instance_domain_name'] %>'
 chef_version='<%= opts['chef_version'] %>'
 username='<%= opts.fetch('user', ENV['USER']) %>'
 encrypted_data_bag_secret_path='<%= opts['chef_data_bag_secret_path'].to_s %>'
-node_json='<%= opts['node_json'] %>'
+node_json=$(cat <<'EOF'
+<%= opts['node_json'] %>
+EOF
+)
 
 ##
 ## common functions


### PR DESCRIPTION
In chef nodes can be passed individual JSON snippets, called *node JSON*. Node JSON is used to customize certain things per node.

Some examples are host names, unique node ids, unique tokens for nodes to 'phone home' and report that they are setup successfully (for load-balancers registration, etc), adding per-node unique software license keys, data to seed the random generator and much more.

This commit adds node-JSON support to stemcell.

`jq` is like `sed` for JSON, is written in c and has no runtime dependencies. Packages exist in the official repositories for Debian, Ubuntu, Fedora, openSUSE, Arch and Solaris (https://stedolan.github.io/jq/). The footprint is small, it clocks in at ~50 kb.

@darnaut Hi Davi, I'm eager to hear your thoughts on this!

Closes #93 