### PR TITLE
Migrate to AWS SDK v3

### DIFF
--- a/spec/lib/stemcell/launcher_spec.rb
+++ b/spec/lib/stemcell/launcher_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 class MockInstance
   def initialize(id)
-    @id = id
+    @id = id.to_s
   end
 
   def id
@@ -37,9 +37,20 @@ describe Stemcell::Launcher do
   let(:instance_ids) { instances.map(&:id) }
 
   describe '#launch' do
-    let(:ec2) { instance_double(AWS::EC2) }
-    let(:client) { double(AWS::EC2::Client) }
-    let(:response) { instance_double(AWS::Core::Response) }
+    let(:ec2) do
+      ec2 = Aws::EC2::Client.new(stub_responses: true)
+      ec2.stub_responses(
+        :describe_security_groups,
+        {
+          security_groups: [
+            {group_id: 'sg-1', group_name: 'sg_name1', vpc_id:'vpc-1'},
+            {group_id: 'sg-2', group_name: 'sg_name2', vpc_id:'vpc-1'},
+          ],
+        }
+      )
+      ec2
+    end
+    let(:response) { instance_double(Seahorse::Client::Response ) }
     let(:launcher) {
       opts = {'region' => 'region', 'vpc_id' => 'vpc-1'}
       launcher = Stemcell::Launcher.new(opts)
@@ -67,15 +78,13 @@ describe Stemcell::Launcher do
       allow(launcher).to receive(:try_file).and_return('secret')
       allow(launcher).to receive(:render_template).and_return('template')
       allow(launcher).to receive(:ec2).and_return(ec2)
-      allow(ec2).to receive(:client).and_return(client)
       allow(response).to receive(:error).and_return(nil)
     end
 
     it 'launches all of the instances' do
       expect(launcher).to receive(:get_vpc_security_group_ids).
         with('vpc-1', ['sg_name1', 'sg_name2']).and_call_original
-      expect_any_instance_of(AWS::EC2::VPC).to receive(:security_groups).
-        and_return([1,2].map { |i| MockSecurityGroup.new("sg-#{i}", "sg_name#{i}", 'vpc-1')})
+      expect(ec2).to receive(:describe_security_groups).and_call_original
       expect(launcher).to receive(:do_launch).with(a_hash_including(
           :image_id           => 'ami-d9d6a6b0',
           :instance_type      => 'c1.xlarge',
@@ -85,7 +94,6 @@ describe Stemcell::Launcher do
           :availability_zone  => 'us-east-1a',
           :user_data          => 'template'
         )).and_return(instances)
-      expect(launcher).to receive(:set_tags).with(kind_of(Array), kind_of(Hash)).and_return(nil)
       # set_classic_link should not be set on vpc hosts.
       expect(launcher).not_to receive(:set_classic_link)
 
@@ -95,19 +103,26 @@ describe Stemcell::Launcher do
     it 'calls set_classic_link for non vpc instances' do
       launcher = Stemcell::Launcher.new({'region' => 'region', 'vpc_id' => false})
       expect(launcher).to receive(:set_classic_link)
-      expect(launcher).to receive(:set_tags).with(kind_of(Array), kind_of(Hash)).and_return(nil)
       expect(launcher).to receive(:do_launch).and_return(instances)
       launcher.send(:launch, launch_options)
     end
   end
 
   describe '#set_classic_link' do
-    let(:ec2) { instance_double(AWS::EC2) }
-    let(:client) { double(AWS::EC2::Client) }
-    let(:response) { instance_double(AWS::Core::Response) }
+    let(:ec2) do
+      ec2 = Aws::EC2::Client.new(stub_responses: true)
+      ec2.stub_responses(
+        :describe_security_groups,
+        {
+          security_groups: [{group_id: 'sg-3', group_name: 'sg_name', vpc_id:'vpc-1'}],
+        }
+      )
+      ec2.stub_responses(:attach_classic_link_vpc, {})
+      ec2
+    end
+    let(:response) { instance_double(Seahorse::Client::Response) }
     before do
       allow(launcher).to receive(:ec2).and_return(ec2)
-      allow(ec2).to receive(:client).and_return(client)
       allow(response).to receive(:error).and_return(nil)
     end
 
@@ -122,21 +137,35 @@ describe Stemcell::Launcher do
     it 'invokes classic link on all of the instances' do
       expect(launcher).to receive(:get_vpc_security_group_ids).with('vpc-1', ['sg_name']).
         and_call_original
-      expect_any_instance_of(AWS::EC2::VPC).to receive(:security_groups).
-        and_return([MockSecurityGroup.new('sg-3', 'sg_name', 'vpc-1')])
-      instances.each do |instance|
-        expect(client).to receive(:attach_classic_link_vpc).ordered.with(a_hash_including(
-            :instance_id => instance.id,
-            :vpc_id => classic_link['vpc_id'],
-            :groups => ['sg-1', 'sg-2', 'sg-3'],
-          )).and_return(response)
-      end
+      # expect(ec2).to receive(:describe_security_groups)
+      # expect(ec2).to receive(:attach_classic_link_vpc)
 
       launcher.send(:set_classic_link, instances, classic_link)
+
+      expect(ec2.api_requests.size).to eq(5)
+      expect(ec2.api_requests.last[:params]).to eq({
+       :instance_id => instances.last.id,
+       :vpc_id => classic_link['vpc_id'],
+       :groups => ['sg-1', 'sg-2', 'sg-3']
+     })
     end
   end
 
   describe '#run_batch_operation' do
+    let(:ec2) do
+      ec2 = Aws::EC2::Client.new(stub_responses: true)
+      ec2.stub_responses(
+        :terminate_instances, -> (context) {
+        instance_id = context.params[:instance_ids].first # we terminate one at a time
+        if instance_id >= '3'
+          Aws::EC2::Errors::InvalidInstanceIDNotFound.new("test", "test")
+        else
+          {} # success
+        end
+      })
+      ec2
+    end
+
     it "raises no exception when no internal error occur" do
       errors = launcher.send(:run_batch_operation, instances) {}
       expect(errors.all?(&:nil?)).to be true
@@ -145,7 +174,7 @@ describe Stemcell::Launcher do
     it "runs full batch even when there are two error" do
       errors = launcher.send(:run_batch_operation,
                              instances) do |instance, error|
-        raise "error-#{instance.id}" if instance.id % 2 == 0
+        raise "error-#{instance.id}" if instance.id.to_i % 2 == 0
       end
       expect(errors.count(&:nil?)).to be_eql(2)
       expect(errors.reject(&:nil?).map { |e| e.message }).to \
@@ -159,7 +188,7 @@ describe Stemcell::Launcher do
         if instance.id == 3
           count += 1
           count < 3 ?
-            AWS::EC2::Errors::InvalidInstanceID::NotFound.new("error-#{instance.id}"):
+            Aws::EC2::Errors::InvalidInstanceIDNotFound.new("error-#{instance.id}"):
             nil
         end
       end
@@ -171,42 +200,47 @@ describe Stemcell::Launcher do
       opts = {'region' => 'region', 'max_attempts' => max_attempts}
       launcher = Stemcell::Launcher.new(opts)
       allow(launcher).to receive(:sleep).and_return(0)
-      tags = double("Tags")
-      instances = (1..2).map do |id|
-        inst = MockInstance.new(id)
-        allow(inst).to receive(:tags).and_return(tags)
-        inst
+      instances = (3..4).map do |id|
+        MockInstance.new(id)
       end
-      expect(tags).to receive(:set).with({'a' => 'b'}).exactly(12).times.
-        and_raise(AWS::EC2::Errors::InvalidInstanceID::NotFound.new("error"))
+      allow(launcher).to receive(:ec2).and_return(ec2)
+      instances.each do |instance|
+        expect(ec2).to receive(:terminate_instances).with(instance_ids: [instance.id]).exactly(6).times.
+          and_raise(Aws::EC2::Errors::InvalidInstanceIDNotFound.new('test', 'test')).and_call_original
+      end
+
       expect do
-        launcher.send(:set_tags, instances, {'a' => 'b'})
+        launcher.send(:kill, instances)
       end.to raise_error(Stemcell::IncompleteOperation)
     end
   end
 
   describe '#configure_aws_creds_and_region' do
-    it 'AWS region is configured after launcher is instanciated' do
-      expect(AWS.config.region).to be_eql('region')
+    it 'AWS region is configured after launcher is instantiated' do
+      expect(Aws.config[:region]).to be_eql('region')
     end
 
     it 'AWS region configuration changed' do
       mock_launcher = Stemcell::Launcher.new('region' => 'ap-northeast-1')
-      expect(AWS.config.region).to be_eql('ap-northeast-1')
+      expect(Aws.config[:region]).to be_eql('ap-northeast-1')
     end
   end
 
   describe '#ec2' do
+    let(:ec2) { Aws::EC2::Client.new(stub_responses: true) }
+
     it 'can return a client with regional endpoint' do
-      launcher = Stemcell::Launcher.new({'region' => 'region1', 'ec2_endpoint' => nil})
+      launcher = Stemcell::Launcher.new({'region' => 'us-east-1', 'ec2_endpoint' => nil})
+      allow(launcher).to receive(:ec2).and_return(ec2)
       client = launcher.send(:ec2)
-      expect(client.config.ec2_endpoint).to be_eql('ec2.region1.amazonaws.com')
+      expect(client.config[:endpoint].to_s).to be_eql('https://ec2.us-east-1.amazonaws.com')
     end
 
     it 'can return a client with custom endpoint' do
-      launcher = Stemcell::Launcher.new({'region' => 'region1', 'ec2_endpoint' => 'endpoint1'})
-      client = launcher.send(:ec2)
-      expect(client.config.ec2_endpoint).to be_eql('endpoint1')
+      launcher = Stemcell::Launcher.new({'region' => 'region1', 'ec2_endpoint' => 'https://endpoint1'})
+      allow(launcher).to receive(:ec2).and_return(ec2)
+      client =  launcher.send(:ec2)
+      expect(client.config[:endpoint].to_s).to be_eql('https://endpoint1')
     end
   end
 end

--- a/stemcell.gemspec
+++ b/stemcell.gemspec
@@ -17,8 +17,11 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'aws-sdk-v1', '~> 1.63'
-  s.add_runtime_dependency 'net-ssh',    '~> 2.9'
+  # pins several aws sdk transitive dependencies to maintain compatibility with Ruby < 2.3
+  s.add_runtime_dependency 'aws-eventstream', '~> 1.1.1'
+  s.add_runtime_dependency 'aws-sdk-ec2',     '~> 1'
+  s.add_runtime_dependency 'aws-sigv4',       '~> 1.2.4'
+  s.add_runtime_dependency 'net-ssh',         '~> 2.9'
   if RUBY_VERSION >= '2.0'
     s.add_runtime_dependency 'chef',     '>= 11.4.0'
   else


### PR DESCRIPTION
Migrating to AWS SDK v3 allows us to take advantage of the lower
resource requirements of the modularized SDK.

More importantly this allows us to set instance tags at launch time in the
RunInstances call rather than have to wait for the instance to reach
'running' state and make a second API call to CreateTags.