### PR TITLE
Add support for specifying --cpu-options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ rvm:
   - 2.1.2
   - 2.2.4
   - 2.3.1
+  - 2.6.8
 before_install:
   - gem install bundler -v 1.16.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.13.1
+- Support for specifying --cpu-options
+
 # 0.13.0
 - Migrate to AWS SDK to v3
 - Drop support for ClassicLink

--- a/lib/stemcell/command_line.rb
+++ b/lib/stemcell/command_line.rb
@@ -132,6 +132,7 @@ module Stemcell
       # comma-separated list when presented as defaults.
       pd['security_groups'] &&= pd['security_groups'].join(',')
       pd['tags'] &&= pd['tags'].to_a.map { |p| p.join('=') }.join(',')
+      pd['cpu_options'] &&= pd['cpu_options'].to_a.map { |p| p.join('=') }.join(',')
       pd['chef_cookbook_attributes'] &&= pd['chef_cookbook_attributes'].join(',')
     end
 

--- a/lib/stemcell/launcher.rb
+++ b/lib/stemcell/launcher.rb
@@ -31,6 +31,7 @@ module Stemcell
       'chef_environment',
       'chef_data_bag_secret',
       'chef_data_bag_secret_path',
+      'cpu_options',
       'git_branch',
       'git_key',
       'git_origin',
@@ -176,6 +177,11 @@ module Stemcell
       # specify raw block device mappings (optional)
       if opts['block_device_mappings']
         launch_options[:block_device_mappings] = opts['block_device_mappings']
+      end
+
+      # specify cpu options (optional)
+      if opts['cpu_options']
+        launch_options[:cpu_options] = opts['cpu_options']
       end
 
       # specify ephemeral block device mappings (optional)

--- a/lib/stemcell/option_parser.rb
+++ b/lib/stemcell/option_parser.rb
@@ -188,6 +188,12 @@ module Stemcell
         :env   => 'CHEF_DATA_BAG_SECRET_PATH'
       },
       {
+        :name => 'cpu_options',
+        :desc => "cpu options",
+        :type => String,
+        :env => 'CPU_OPTIONS'
+      },
+      {
         :name => 'chef_role',
         :desc => "chef role of instance to be launched",
         :type => String,
@@ -343,6 +349,16 @@ module Stemcell
           tags[key] = value
         end
         options['tags'] = tags
+      end
+
+      # convert cpu_options from comma separated string to ruby hash
+      if options['cpu_options']
+        cpu_options = {}
+        options['cpu_options'].split(',').each do |cpu_opt|
+          key, value = cpu_opt.split('=')
+          cpu_options[key] = value
+        end
+        options['cpu_options'] = cpu_options
       end
 
       # parse block_device_mappings to convert it from the standard CLI format

--- a/lib/stemcell/option_parser.rb
+++ b/lib/stemcell/option_parser.rb
@@ -189,7 +189,7 @@ module Stemcell
       },
       {
         :name => 'cpu_options',
-        :desc => "cpu options",
+        :desc => "comma-separated list of cpu option key=value pairs",
         :type => String,
         :env => 'CPU_OPTIONS'
       },

--- a/lib/stemcell/version.rb
+++ b/lib/stemcell/version.rb
@@ -1,3 +1,3 @@
 module Stemcell
-  VERSION = "0.13.0"
+  VERSION = "0.13.1"
 end

--- a/spec/lib/stemcell/launcher_spec.rb
+++ b/spec/lib/stemcell/launcher_spec.rb
@@ -71,7 +71,8 @@ describe Stemcell::Launcher do
         'count'                   => 2,
         'security_groups'         => ['sg_name1', 'sg_name2'],
         'user'                    => 'some_user',
-        'wait'                    => true
+        'wait'                    => true,
+        'cpu_options'             => 'core_count=1,threads_per_core=1'
       }
     }
 
@@ -107,7 +108,8 @@ describe Stemcell::Launcher do
                 { :key => "stemcell",   :value => Stemcell::VERSION },
               ]},
           ],
-          :user_data          => Base64.encode64('template')
+          :user_data          => Base64.encode64('template'),
+          :cpu_options        => 'core_count=1,threads_per_core=1'
         )).and_return(instances)
       launched_instances = launcher.send(:launch, launch_options)
       expect(launched_instances.map(&:public_ip_address)).to all(be_truthy)


### PR DESCRIPTION
We want to try out `--cpu-options` in order to test behavior when disabling multi-threading on various AWS instances: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-specify-cpu-options.html

This requires the low-level AWS SDK v3 API change that @kunickiaj introduces in their PR: https://github.com/airbnb/stemcell/pull/107

This API allows you to specify these options: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/EC2/Client.html#run_instances-instance_method
```
    cpu_options: {
      core_count: 1,
      threads_per_core: 1,
    },
 ```
 
 To test this change:
 ```
 gem build stemcell.gemspec
 gem install ./stemcell-0.13.1.gem
 ```
 Then:
 ```
(AssumedRole=prod-admin) bash-3.2$ stemcell --local-chef-root /Users/melanie_cebula/airlab/repos/chef --chef-role testbox-amzn --git-branch production --region us-east-1 --key-name ssh_melanie_cebula --instance-type t3.medium --vpc-id vpc-e577cd9d --instance-domain-name inst.aws.us-east-1.prod.musta.ch --git-origin git@commitment.musta.ch:airbnb/chef.git --availability-zone us-east-1a --subnet subnet-05838f4e --ssh-user ec2-user --count 1 --chef-data-bag-secret="$CHEF_DATA_BAG_SECRET" --git-key="$GIT_KEY" --cpu-options="core_count=1,threads_per_core=1"
 ```
 
 Verify:
 ```
(AssumedRole=prod-admin) bash-3.2$ aws ec2 describe-instances --instance-ids i-038d65d57548ace56 | grep Core
                        "CoreCount": 1,
                        "ThreadsPerCore": 1
```

p.s. added ruby `2.6.8` to run locally on my Apple M1 (arm64 support)-- I can also add a `.ruby-version` file if we want everyone to standardize on a version
@kunickiaj @darnaut 
