### PR TITLE
Support for specifying minimum and maximum number of instances to launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # 0.13.1
+- Support for specifying --min-count and --max-count
+
+# 0.13.1
 - Support for specifying --cpu-options
 
 # 0.13.0

--- a/lib/stemcell/launcher.rb
+++ b/lib/stemcell/launcher.rb
@@ -47,6 +47,8 @@ module Stemcell
       'dedicated_tenancy',
       'associate_public_ip_address',
       'count',
+      'min_count',
+      'max_count',
       'security_groups',
       'security_group_ids',
       'tags',
@@ -102,15 +104,18 @@ module Stemcell
       tags['Name'] = opts['chef_role'] if opts['chef_environment'] == 'production'
       tags.merge!(opts['tags']) if opts['tags']
 
+      #  Min/max number of instances to launch
+      min_count = opts['min_count'] || opts['count']
+      max_count = opts['max_count'] || opts['count']
+
       # generate launch options
       launch_options = {
         :image_id => opts['image_id'],
         :instance_type => opts['instance_type'],
         :key_name => opts['key_name'],
-        :min_count => opts['count'],
-        :max_count => opts['count'],
+        :min_count => min_count,
+        :max_count => max_count,
       }
-
 
       # Associate Public IP can only bet set on network_interfaces, and if present
       # security groups and subnet should be set on the interface. VPC-only.

--- a/lib/stemcell/option_parser.rb
+++ b/lib/stemcell/option_parser.rb
@@ -260,6 +260,18 @@ module Stemcell
         :env   => 'COUNT'
       },
       {
+        :name  => 'min_count',
+        :desc  => "minimum number of instances to launch",
+        :type  => Integer,
+        :env   => 'MIN_COUNT'
+      },
+      {
+        :name  => 'max_count',
+        :desc  => "maximum number of instances to launch",
+        :type  => Integer,
+        :env   => 'MAX_COUNT'
+      },
+      {
         :name  => 'tail',
         :desc  => "interactively tail the initial converge",
         :type  => nil,

--- a/lib/stemcell/version.rb
+++ b/lib/stemcell/version.rb
@@ -1,3 +1,3 @@
 module Stemcell
-  VERSION = "0.13.1"
+  VERSION = "0.13.2"
 end

--- a/spec/lib/stemcell/launcher_spec.rb
+++ b/spec/lib/stemcell/launcher_spec.rb
@@ -114,6 +114,19 @@ describe Stemcell::Launcher do
       launched_instances = launcher.send(:launch, launch_options)
       expect(launched_instances.map(&:public_ip_address)).to all(be_truthy)
     end
+
+    it 'launches with min/max count' do
+      expect(launcher).to receive(:do_launch).with(a_hash_including(
+        :min_count => 3,
+        :max_count => 6,
+      )).and_return(instances)
+      options = launch_options.merge(
+        'min_count' => 3,
+        'max_count' => 6,
+      )
+      launched_instances = launcher.send(:launch,
+        launch_options.merge('min_count' => 3, 'max_count' => 6))
+    end
   end
 
   describe '#kill' do


### PR DESCRIPTION
AWS SDK for Ruby V3 no longer supports a `count` option for `#run_instances`, which before could be used for specifying a minimum and maximum number of instances to launch. This change introduces optional min/max options.