### PR TITLE
Allow the Stemcell launcher to accept a custom launch bootstrap template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# 0.13.1
+# 0.14.0
+- Adds support for specifying a custom bootstrap template file
+
+# 0.13.2
 - Support for specifying --min-count and --max-count
 
 # 0.13.1

--- a/lib/stemcell/launcher.rb
+++ b/lib/stemcell/launcher.rb
@@ -83,7 +83,7 @@ module Stemcell
       @aws_secret_key = opts['aws_secret_key']
       @aws_session_token = opts['aws_session_token']
       @max_attempts = opts['max_attempts'] || 3
-      @launch_template_path = opts['launch_template_path']
+      @bootstrap_template_path = opts['bootstrap_template_path']
       configure_aws_creds_and_region
     end
 
@@ -258,7 +258,7 @@ module Stemcell
 
     # this is made public for ec2admin usage
     def render_template(opts={})
-      template_file_path = @launch_template_path || File.expand_path(TEMPLATE_PATH, __FILE__)
+      template_file_path = @bootstrap_template_path || File.expand_path(TEMPLATE_PATH, __FILE__)
       template_file = File.read(template_file_path)
       erb_template = ERB.new(template_file)
       last_bootstrap_line = LAST_BOOTSTRAP_LINE

--- a/lib/stemcell/launcher.rb
+++ b/lib/stemcell/launcher.rb
@@ -83,6 +83,7 @@ module Stemcell
       @aws_secret_key = opts['aws_secret_key']
       @aws_session_token = opts['aws_session_token']
       @max_attempts = opts['max_attempts'] || 3
+      @launch_template_path = opts['launch_template_path']
       configure_aws_creds_and_region
     end
 
@@ -257,7 +258,7 @@ module Stemcell
 
     # this is made public for ec2admin usage
     def render_template(opts={})
-      template_file_path = File.expand_path(TEMPLATE_PATH, __FILE__)
+      template_file_path = @launch_template_path || File.expand_path(TEMPLATE_PATH, __FILE__)
       template_file = File.read(template_file_path)
       erb_template = ERB.new(template_file)
       last_bootstrap_line = LAST_BOOTSTRAP_LINE

--- a/lib/stemcell/version.rb
+++ b/lib/stemcell/version.rb
@@ -1,3 +1,3 @@
 module Stemcell
-  VERSION = "0.13.2"
+  VERSION = "0.14.0"
 end

--- a/spec/lib/stemcell/launcher_spec.rb
+++ b/spec/lib/stemcell/launcher_spec.rb
@@ -25,7 +25,7 @@ describe Stemcell::Launcher do
 
   describe '#render_template' do
 
-    context 'when launch_template_path is not provided' do
+    context 'when bootstrap_template_path is not provided' do
       let(:subject) do
         launcher.render_template()
       end
@@ -43,13 +43,13 @@ describe Stemcell::Launcher do
       end
     end
 
-    context 'when launch_template_path is provided' do
+    context 'when bootstrap_template_path is provided' do
       let(:subject) do
         launcher.render_template()
       end
 
       let(:launcher) do
-        opts = {'region' => 'region', 'vpc_id' => 'vpc-1', 'launch_template_path' => '/path/to/file.sh.erb'}
+        opts = {'region' => 'region', 'vpc_id' => 'vpc-1', 'bootstrap_template_path' => '/path/to/file.sh.erb'}
         launcher = Stemcell::Launcher.new(opts)
 
         launcher

--- a/spec/lib/stemcell/launcher_spec.rb
+++ b/spec/lib/stemcell/launcher_spec.rb
@@ -23,6 +23,51 @@ describe Stemcell::Launcher do
   end
   let(:instance_ids) { instances.map(&:id) }
 
+  describe '#render_template' do
+
+    context 'when launch_template_path is not provided' do
+      let(:subject) do
+        launcher.render_template()
+      end
+
+      before do
+        allow(File).to receive(:expand_path).and_return('/path/to/default/bootstrap.sh.erb')
+        allow(File).to receive(:read).and_return('default template content')
+      end
+
+      it 'launches the default template' do
+        expect(File).to receive(:expand_path)
+        expect(File).to receive(:read).with('/path/to/default/bootstrap.sh.erb')
+
+        expect(subject).not_to be_empty
+      end
+    end
+
+    context 'when launch_template_path is provided' do
+      let(:subject) do
+        launcher.render_template()
+      end
+
+      let(:launcher) do
+        opts = {'region' => 'region', 'vpc_id' => 'vpc-1', 'launch_template_path' => '/path/to/file.sh.erb'}
+        launcher = Stemcell::Launcher.new(opts)
+
+        launcher
+      end
+
+      before do
+        allow(File).to receive(:read).and_return('custom template content')
+      end
+
+      it 'launches the override template' do
+        expect(File).not_to receive(:expand_path)
+        expect(File).to receive(:read).with('/path/to/file.sh.erb')
+
+        expect(subject).not_to be_empty
+      end
+    end
+  end
+
   describe '#launch' do
     let(:ec2) do
       ec2 = Aws::EC2::Client.new


### PR DESCRIPTION
To: @kunickiaj  @darnaut 

Adds a new option to the `Stemcell::Launcher` which allows the specification of a `bootstrap_template_path` — an absolute filepath to an `.erb` template that will be used to bootstrap the EC2 instance during `run_instances`.

If no `bootstrap_template_path` is provided, it will default to the original template that is shipped with Stemcell.