### PR TITLE
Upgrades Chef to 18 and Nokogiri to 1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.15.0
+- Upgrade Chef to 18 and Nokogiri to 1.16 for compatibility with newer Ruby versions
+
 # 0.14.0
 - Adds support for specifying a custom bootstrap template file
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,4 @@ group :test do
   gem 'rake', '~> 10.3.2'
 end
 
-gem 'nokogiri', '~> 1.8.2'
+gem 'nokogiri', '~> 1.16.0'

--- a/lib/stemcell/version.rb
+++ b/lib/stemcell/version.rb
@@ -1,3 +1,3 @@
 module Stemcell
-  VERSION = "0.14.1"
+  VERSION = "0.15.0"
 end

--- a/spec/lib/stemcell/metadata_source/chef_repository_spec.rb
+++ b/spec/lib/stemcell/metadata_source/chef_repository_spec.rb
@@ -116,7 +116,7 @@ describe Stemcell::MetadataSource::ChefRepository do
         let(:role) { 'unit-simple-none' }
         let(:cookbook_attributes) { ['unknown::attr'] }
         it "raises an error" do
-          expect { result_metadata }.to raise_error(Chef::Exceptions::CookbookNotFound)
+          expect { result_metadata }.to raise_error(Chef::Exceptions::CookbookNotFoundInRepo)
         end
       end
 

--- a/stemcell.gemspec
+++ b/stemcell.gemspec
@@ -26,10 +26,10 @@ Gem::Specification.new do |s|
   if RUBY_VERSION >= '2.0'
     s.add_runtime_dependency 'chef',     '>= 11.4.0'
   else
-    s.add_runtime_dependency 'chef',     ['>= 11.4.0', '< 12.0.0']
+    s.add_runtime_dependency 'chef',     ['>= 11.4.0', '< 19.0.0']
   end
 
-  s.add_runtime_dependency 'nokogiri', '~> 1.8.2'
+  s.add_runtime_dependency 'nokogiri', '~> 1.16.0'
   s.add_runtime_dependency 'ffi-yajl', '< 2.3.1'
 
   s.add_runtime_dependency 'trollop',    '~> 2.1'


### PR DESCRIPTION
This is for compatibility with newer ruby versions e.g. 3.3